### PR TITLE
[SHOW] docs: README 구조를 서비스별 문서로 재구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,30 @@
-# lifepuzzle-api
+# lifepuzzle-backend
 
-### Project Structure
+## Services
+
+This monorepo contains the following services:
+
+- **[lifepuzzle-api](./services/lifepuzzle-api/README.md)** - Spring Boot REST API service
+- **[image-resizer](./services/image-resizer/README.md)** - Go-based image processing service
+
+## Shared Libraries
+
+- **shared/java-common** - Common Java utilities and configurations
+- **shared/go-common** - Common Go packages
+
+## Project Structure
 
 ```bash
-lifepuzzle
-│
-├── domain
-│   ├── hero
-│   │   ├── endpoint
-│   │   │   ├── response [ 외부 요청에 대한 응답 관련 클래스 폴더 ]
-│   │   │   ├── request  [ 외부 요청에 대한 요청 관련 클래스 폴더 ]
-│   │   │   └── HeroQueryEndpoint.java
-│   │   ├── service [ 비즈니스 로직 폴더 ]
-│   │   ├── repository [ DB 관련 클래스 폴더 ]
-│   │   └── entity [ 엔티티 클래스 폴더 ]
-│   ├── story
-│   └── ...
-│
-├── global
-│   ├── ai
-│   ├── aop
-│   ├── config
-│   ├── constant
-│   ├── exception
-│   ├── infra
-│   ├── monitoring
-│   ├── resolver
-│   ├── slack
-│   └── util
-│
-└── LifePuzzleApplication.Java
+lifepuzzle-backend/
+├── services/
+│   ├── lifepuzzle-api/          # Spring Boot API service
+│   └── image-resizer/           # Go image processing service
+├── shared/
+│   ├── java-common/             # Shared Java libraries
+│   └── go-common/               # Shared Go libraries
+└── tools/
+    ├── checkstyle/              # Code style configuration
+    └── scripts/                 # Build and deployment scripts
 ```
 
 ### Versioning [수정 필요]

--- a/services/image-resizer/README.md
+++ b/services/image-resizer/README.md
@@ -1,0 +1,178 @@
+# image-resizer
+
+Go-based microservice for asynchronous image processing and resizing.
+
+## Project Structure
+
+```bash
+image-resizer/
+├── main.go                           # Application entry point
+├── config/
+│   └── config.go                     # Configuration management
+├── database/
+│   └── database.go                   # Database connection & operations
+├── messaging/
+│   └── rabbitmq.go                   # RabbitMQ message handling
+├── resizer/
+│   └── resizer.go                    # Image resizing logic
+├── storage/
+│   └── s3.go                         # S3 storage operations
+├── k8s-mysql.yaml                    # Kubernetes MySQL deployment
+├── k8s-rabbitmq.yaml                # Kubernetes RabbitMQ deployment
+├── Dockerfile                        # Container image build
+├── Dockerfile.standalone             # Standalone container build
+├── go.mod                           # Go module dependencies
+└── go.sum                           # Go module checksums
+```
+
+## Architecture
+
+The image-resizer service follows a message-driven architecture:
+
+1. **Message Queue**: Receives resize requests via RabbitMQ
+2. **Image Processing**: Downloads, resizes, and optimizes images
+3. **Storage**: Uploads processed images to S3
+4. **Database**: Updates metadata and status
+
+## Features
+
+- **Asynchronous Processing**: Queue-based image processing
+- **Multiple Formats**: Support for various image formats
+- **Size Optimization**: Automatic image compression and optimization
+- **Scalable**: Kubernetes-ready with horizontal scaling
+- **Monitoring**: Health checks and processing metrics
+
+## Technology Stack
+
+- **Language**: Go 1.21+
+- **Message Queue**: RabbitMQ
+- **Storage**: AWS S3
+- **Database**: MySQL (shared with lifepuzzle-api)
+- **Container**: Docker
+- **Orchestration**: Kubernetes
+
+## Configuration
+
+The service is configured via environment variables:
+
+```bash
+# Database
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=lifepuzzle
+DB_USER=user
+DB_PASSWORD=password
+
+# RabbitMQ
+RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+
+# AWS S3
+AWS_REGION=us-west-2
+AWS_ACCESS_KEY_ID=your-key
+AWS_SECRET_ACCESS_KEY=your-secret
+S3_BUCKET=your-bucket
+
+# Application
+PORT=8080
+LOG_LEVEL=info
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.21+
+- RabbitMQ
+- MySQL (shared with lifepuzzle-api)
+- AWS S3 bucket and credentials
+
+### Local Development
+
+```bash
+# Install dependencies
+go mod download
+
+# Run the service
+go run main.go
+
+# Build binary
+go build -o image-resizer main.go
+```
+
+### Docker
+
+```bash
+# Build image
+docker build -t image-resizer .
+
+# Run container
+docker run -p 8080:8080 \
+  -e DB_HOST=host.docker.internal \
+  -e RABBITMQ_URL=amqp://guest:guest@host.docker.internal:5672/ \
+  image-resizer
+```
+
+### Kubernetes Deployment
+
+The service includes Kubernetes manifests for dependencies:
+
+```bash
+# Deploy MySQL
+kubectl apply -f k8s-mysql.yaml
+
+# Deploy RabbitMQ
+kubectl apply -f k8s-rabbitmq.yaml
+
+# Deploy the service (use your own deployment manifest)
+kubectl apply -f your-deployment.yaml
+```
+
+## API Endpoints
+
+### Health Check
+
+```http
+GET /health
+```
+
+Returns service health status and dependency connectivity.
+
+### Metrics
+
+```http
+GET /metrics
+```
+
+Returns processing metrics and queue status.
+
+## Message Format
+
+The service processes messages with the following JSON format:
+
+```json
+{
+  "image_url": "https://example.com/original.jpg",
+  "target_sizes": [
+    {"width": 300, "height": 300, "quality": 80},
+    {"width": 800, "height": 600, "quality": 90}
+  ],
+  "output_format": "jpeg",
+  "callback_url": "https://api.example.com/callback"
+}
+```
+
+## Monitoring
+
+The service provides:
+- Health check endpoint for liveness/readiness probes
+- Metrics for processing performance
+- Structured logging for debugging
+- Error tracking and alerting
+
+## Scaling
+
+The service is designed for horizontal scaling:
+- Stateless processing
+- Queue-based work distribution
+- Kubernetes-ready configuration
+- Resource-efficient Go runtime

--- a/services/lifepuzzle-api/README.md
+++ b/services/lifepuzzle-api/README.md
@@ -1,0 +1,145 @@
+# lifepuzzle-api
+
+Spring Boot REST API service for the LifePuzzle application.
+
+## Project Structure
+
+```bash
+lifepuzzle-api/
+├── src/main/java/io/itmca/lifepuzzle/
+│   ├── LifePuzzleApplication.java
+│   ├── domain/
+│   │   ├── auth/                     # Authentication & Authorization
+│   │   │   ├── endpoint/             # REST endpoints
+│   │   │   ├── jwt/                  # JWT token handling
+│   │   │   ├── service/              # Auth business logic
+│   │   │   └── type/                 # Auth types & enums
+│   │   ├── hero/                     # Hero management
+│   │   │   ├── endpoint/             # Hero REST endpoints
+│   │   │   ├── entity/               # Hero JPA entities
+│   │   │   ├── file/                 # Hero file handling
+│   │   │   ├── repository/           # Data access layer
+│   │   │   ├── service/              # Hero business logic
+│   │   │   └── type/                 # Hero types & enums
+│   │   ├── story/                    # Story management
+│   │   │   ├── endpoint/             # Story REST endpoints
+│   │   │   ├── entity/               # Story JPA entities
+│   │   │   ├── file/                 # Story file handling
+│   │   │   ├── repository/           # Data access layer
+│   │   │   ├── service/              # Story business logic
+│   │   │   └── type/                 # Story types & enums
+│   │   ├── user/                     # User management
+│   │   │   ├── endpoint/             # User REST endpoints
+│   │   │   ├── entity/               # User JPA entities
+│   │   │   ├── file/                 # User file handling
+│   │   │   ├── model/                # Domain models
+│   │   │   ├── repository/           # Data access layer
+│   │   │   ├── service/              # User business logic
+│   │   │   └── type/                 # User types & enums
+│   │   ├── gallery/                  # Gallery management
+│   │   │   ├── endpoint/             # Gallery REST endpoints
+│   │   │   ├── repository/           # Data access layer
+│   │   │   └── service/              # Gallery business logic
+│   │   └── sites/                    # App linking & sharing
+│   │       └── *.java                # Universal links & app links
+│   └── global/
+│       ├── ai/                       # AI integrations
+│       │   ├── chat/                 # OpenAI chat service
+│       │   └── stt/                  # Speech-to-text service
+│       ├── aop/                      # Aspect-oriented programming
+│       ├── config/                   # Application configuration
+│       ├── exception/                # Exception handling
+│       │   └── handler/              # Global exception handlers
+│       ├── file/                     # File management
+│       │   ├── repository/           # File storage (S3)
+│       │   └── service/              # File upload services
+│       ├── jpa/                      # JPA configurations
+│       ├── resolver/                 # Argument resolvers
+│       ├── slack/                    # Slack integrations
+│       └── util/                     # Utility classes
+├── src/main/resources/
+│   ├── application*.yml              # Environment configurations
+│   ├── db/migration/                 # Flyway database migrations
+│   ├── logback-spring.xml            # Logging configuration
+│   └── templates/                    # HTML templates
+├── src/test/                         # Test code
+│   └── java/io/itmca/lifepuzzle/
+│       ├── domain/                   # Domain-specific tests
+│       └── testsupport/              # Test utilities
+└── http/                             # HTTP test files
+    ├── login.http
+    ├── register.http
+    └── withdraw.http
+```
+
+## Domain Architecture
+
+Each domain follows a consistent structure:
+
+```bash
+domain/{domain-name}/
+├── endpoint/                         # REST API endpoints
+│   ├── request/                      # Request DTOs
+│   ├── response/                     # Response DTOs
+│   │   └── dto/                      # Data transfer objects
+│   └── {Domain}Endpoint.java
+├── entity/                           # JPA entities
+├── repository/                       # Data access repositories
+├── service/                          # Business logic services
+├── file/                            # File-related classes
+├── model/                           # Domain models
+└── type/                            # Enums and type definitions
+```
+
+## Key Features
+
+- **Authentication**: JWT-based auth with Apple/Kakao social login
+- **Hero Management**: Create and manage hero profiles
+- **Story System**: Story creation with multimedia support
+- **Gallery**: Photo and content organization
+- **File Handling**: S3-based file storage with image resizing
+- **AI Integration**: OpenAI chat and Deepgram speech-to-text
+- **Monitoring**: Sentry integration with Slack notifications
+
+## Technology Stack
+
+- **Framework**: Spring Boot
+- **Database**: MySQL with Flyway migrations
+- **Authentication**: JWT with social login (Apple, Kakao)
+- **File Storage**: AWS S3
+- **AI Services**: OpenAI, Deepgram
+- **Monitoring**: Sentry
+- **Testing**: JUnit with integration test support
+
+## Getting Started
+
+### Prerequisites
+
+- Java 11+
+- MySQL 8.0+
+- AWS S3 bucket
+- Required API keys (OpenAI, Deepgram, social login providers)
+
+### Configuration
+
+Configure environment-specific settings in:
+- `application-local.yml` - Local development
+- `application-test.yml` - Testing
+- `application-prod.yml` - Production
+
+### Running the Application
+
+```bash
+# Development
+./gradlew bootRun --args='--spring.profiles.active=local'
+
+# Tests
+./gradlew test
+```
+
+### HTTP Testing
+
+Use the provided HTTP files in the `http/` directory to test endpoints:
+- `login.http` - Authentication testing
+- `register.http` - User registration testing
+- `withdraw.http` - User withdrawal testing


### PR DESCRIPTION
## 요약
- 메인 README를 모노레포 개요로 업데이트하고 각 서비스별 상세 문서 링크 추가
- lifepuzzle-api 서비스에 대한 포괄적인 문서 작성 (아키텍처, 기능, 기술 스택 포함)
- image-resizer 서비스에 대한 상세 문서 작성 (배포 가이드 및 설정 포함)

## 변경 사항
- `README.md`: 모노레포 구조 개요 및 서비스 링크로 재구성
- `services/lifepuzzle-api/README.md`: Spring Boot API 서비스 상세 문서 신규 작성
- `services/image-resizer/README.md`: Go 이미지 처리 서비스 상세 문서 신규 작성

## 테스트 계획
- [ ] 문서 링크가 올바르게 작동하는지 확인
- [ ] 각 서비스 문서의 내용이 현재 코드베이스와 일치하는지 검토
- [ ] 개발자 온보딩 프로세스에서 문서 유용성 확인

🤖 Generated with [Claude Code](https://claude.ai/code)