### PR TITLE
[SHOW] fix: improve exception logging and add debug support for production

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -25,6 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     try {
       trySettingAuthentication(request);
     } catch (JwtException e) {
+      logger.debug("JWT authentication failed: " + e.getMessage());
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       return;
     }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/handler/CustomExceptionHandler.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/handler/CustomExceptionHandler.java
@@ -13,41 +13,49 @@ public class CustomExceptionHandler {
 
   @ExceptionHandler(AuthException.class)
   public ResponseEntity handleUnAuthorizedException(AuthException e) {
+    log.debug("Auth exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
   }
 
   @ExceptionHandler(NotFoundException.class)
   public ResponseEntity handleNotFoundException(NotFoundException e) {
+    log.debug("Not found exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
   }
 
   @ExceptionHandler(AlreadyExistsException.class)
   public ResponseEntity handleAlreadyExistsException(AlreadyExistsException e) {
+    log.debug("Already exists exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.CONFLICT).build();
   }
 
   @ExceptionHandler(ServerExecutionFailException.class)
   public ResponseEntity handleServerExecutionFailException(ServerExecutionFailException e) {
+    log.info("Server execution fail exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }
 
   @ExceptionHandler(MissingArgumentException.class)
   public ResponseEntity handleIllegalArgumentException(MissingArgumentException e) {
+    log.debug("Missing argument exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
   }
 
   @ExceptionHandler(AccessDeniedException.class)
   public ResponseEntity handleAccessDeniedException(AccessDeniedException e) {
+    log.debug("Access denied exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
   }
 
   @ExceptionHandler(ExpiredException.class)
   public ResponseEntity handleExpiredException(ExpiredException e) {
+    log.debug("Expired exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
   }
 
   @ExceptionHandler(ExternalApiException.class)
   public ResponseEntity handleExternalApiException(ExternalApiException e) {
+    log.info("External API exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
   }
 }

--- a/services/lifepuzzle-api/src/main/resources/logback-spring.xml
+++ b/services/lifepuzzle-api/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <!-- Configure the Console appender -->
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -14,7 +14,7 @@
         </filter>
         <!-- Optionally add an encoder -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -27,9 +27,12 @@
     </springProfile>
 
     <springProfile name="prod">
-        <root level="INFO">
+        <root level="DEBUG">
             <appender-ref ref="Console"/>
-            <appender-ref ref="Sentry"/>
         </root>
+        <!-- TODO: 디버깅 완료 후 DEBUG를 INFO로 되돌리고 Sentry appender 추가하기 -->
+        <logger name="ROOT" level="INFO" additivity="false">
+            <appender-ref ref="Sentry"/>
+        </logger>
     </springProfile>
 </configuration>


### PR DESCRIPTION
## 작업 배경
- 예외 발생 시 로그가 전혀 출력되지 않아 디버깅이 어려운 상황
- 프로덕션 환경에서 발생하는 이슈 추적을 위한 임시 디버그 로깅 필요
- 예외 종류에 따른 적절한 로그 레벨 설정 필요

## 작업 내용
- CustomExceptionHandler에 구조화된 예외 로깅 추가
  - 4xx 에러: DEBUG 레벨 (클라이언트 사이드 이슈)
  - 5xx 에러: INFO 레벨 (서버 사이드 이슈)
- JwtAuthenticationFilter에 JWT 인증 실패 시 DEBUG 로깅 추가
- 로그 포맷에 전체 타임스탬프(날짜 포함) 추가
- 프로덕션 환경에서 콘솔 로깅을 임시로 DEBUG 레벨로 설정
- Sentry는 기존과 동일하게 INFO 레벨 이상만 전송하도록 분리

## 참고 사항
- ⚠️ **프로덕션 콘솔 로깅이 임시로 DEBUG 레벨로 설정됨** - 이슈 해결 후 INFO 레벨로 되돌려야 함
- TODO 주석으로 되돌릴 항목 표시해둠
- 테스트 완료 후 logback-spring.xml의 prod 설정을 원래대로 복구 필요

🤖 Generated with [Claude Code](https://claude.ai/code)