### PR TITLE
[SHOW] feat: add individual deployment scripts for MySQL and RabbitMQ

### DIFF
--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -14,7 +14,52 @@ A comprehensive Helm chart that manages MySQL and RabbitMQ infrastructure using 
 - Kubernetes cluster
 - kubectl configured
 
-## Quick Start
+## Deployment Options
+
+### Full Infrastructure Deployment
+Deploy both MySQL and RabbitMQ together:
+```bash
+./deploy-prod.sh
+```
+
+### Individual Component Deployments
+
+#### MySQL Only
+```bash
+./deploy-mysql-prod.sh
+```
+Required environment variables:
+- `MYSQL_ROOT_PASSWORD`
+- `MYSQL_PASSWORD`
+
+#### RabbitMQ Only
+```bash
+./deploy-rabbitmq-prod.sh
+```
+Required environment variables:
+- `RABBITMQ_PASSWORD`
+- `RABBITMQ_ERLANG_COOKIE`
+
+### Environment Variables Setup
+```bash
+# MySQL credentials
+export MYSQL_ROOT_PASSWORD='your-secure-root-password'
+export MYSQL_PASSWORD='your-secure-lifepuzzle-password'
+
+# RabbitMQ credentials
+export RABBITMQ_PASSWORD='your-secure-rabbitmq-password'
+export RABBITMQ_ERLANG_COOKIE='your-secure-erlang-cookie'
+```
+
+## Helm Releases
+
+| Script | Helm Release Name | Components |
+|--------|------------------|------------|
+| `deploy-prod.sh` | `lifepuzzle-infra` | MySQL + RabbitMQ |
+| `deploy-mysql-prod.sh` | `lifepuzzle-mysql` | MySQL only |
+| `deploy-rabbitmq-prod.sh` | `lifepuzzle-rabbitmq` | RabbitMQ only |
+
+## Manual Installation
 
 ### 1. Add Bitnami Repository
 

--- a/infra/helm/deploy-mysql-prod.sh
+++ b/infra/helm/deploy-mysql-prod.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# MySQL-only production deployment script for LifePuzzle Infrastructure
+# Usage: ./deploy-mysql-prod.sh
+
+set -e
+
+echo "🗄️ Deploying MySQL to Production..."
+
+# Check if required environment variables are set
+required_vars=(
+    "MYSQL_ROOT_PASSWORD"
+    "MYSQL_PASSWORD"
+)
+
+echo "🔍 Checking environment variables..."
+for var in "${required_vars[@]}"; do
+    if [[ -z "${!var}" ]]; then
+        echo "❌ Error: Environment variable $var is not set"
+        echo "Please set all required variables:"
+        echo "  export MYSQL_ROOT_PASSWORD='your-secure-root-password'"
+        echo "  export MYSQL_PASSWORD='your-secure-lifepuzzle-password'"
+        exit 1
+    fi
+    echo "✅ $var is set"
+done
+
+# Add Bitnami repository if not already added
+echo "📦 Adding Bitnami Helm repository..."
+helm repo add bitnami https://charts.bitnami.com/bitnami || true
+helm repo update
+
+# Deploy or upgrade MySQL only
+echo "🔧 Deploying MySQL..."
+helm upgrade --install lifepuzzle-mysql ./lifepuzzle-infrastructure \
+    --namespace lifepuzzle \
+    --create-namespace \
+    --values ./lifepuzzle-infrastructure/values-prod.yaml \
+    --set mysql.enabled=true \
+    --set rabbitmq.enabled=false \
+    --set mysql.auth.rootPassword="$MYSQL_ROOT_PASSWORD" \
+    --set mysql.auth.password="$MYSQL_PASSWORD" \
+    --wait \
+    --timeout=10m
+
+echo "✅ MySQL deployment completed successfully!"
+
+# Show deployment status
+echo "📊 MySQL Deployment Status:"
+helm status lifepuzzle-mysql -n lifepuzzle
+
+echo ""
+echo "🔍 MySQL Pod Status:"
+kubectl get pods -n lifepuzzle -l app.kubernetes.io/component=primary
+
+echo ""
+echo "🌐 MySQL Service Status:"
+kubectl get svc -n lifepuzzle -l app.kubernetes.io/name=mysql
+
+echo ""
+echo "💡 Next Steps:"
+echo "1. Verify MySQL pod is running: kubectl get pods -n lifepuzzle -l app.kubernetes.io/name=mysql"
+echo "2. Check MySQL logs: kubectl logs -f <mysql-pod-name> -n lifepuzzle"
+echo "3. Connect to MySQL:"
+echo "   kubectl port-forward svc/lifepuzzle-mysql 3306:3306 -n lifepuzzle"

--- a/infra/helm/deploy-prod.sh
+++ b/infra/helm/deploy-prod.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-# Production deployment script for LifePuzzle Infrastructure
+# Full infrastructure production deployment script for LifePuzzle Infrastructure
+# This deploys both MySQL and RabbitMQ together
 # Usage: ./deploy-prod.sh
+# 
+# For individual deployments, use:
+# - ./deploy-mysql-prod.sh (MySQL only)
+# - ./deploy-rabbitmq-prod.sh (RabbitMQ only)
 
 set -e
 
-echo "🚀 Deploying LifePuzzle Infrastructure to Production..."
+echo "🚀 Deploying Full LifePuzzle Infrastructure to Production..."
 
 # Check if required environment variables are set
 required_vars=(

--- a/infra/helm/deploy-rabbitmq-prod.sh
+++ b/infra/helm/deploy-rabbitmq-prod.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# RabbitMQ-only production deployment script for LifePuzzle Infrastructure
+# Usage: ./deploy-rabbitmq-prod.sh
+
+set -e
+
+echo "🐰 Deploying RabbitMQ to Production..."
+
+# Check if required environment variables are set
+required_vars=(
+    "RABBITMQ_PASSWORD"
+    "RABBITMQ_ERLANG_COOKIE"
+)
+
+echo "🔍 Checking environment variables..."
+for var in "${required_vars[@]}"; do
+    if [[ -z "${!var}" ]]; then
+        echo "❌ Error: Environment variable $var is not set"
+        echo "Please set all required variables:"
+        echo "  export RABBITMQ_PASSWORD='your-secure-rabbitmq-password'"
+        echo "  export RABBITMQ_ERLANG_COOKIE='your-secure-erlang-cookie'"
+        exit 1
+    fi
+    echo "✅ $var is set"
+done
+
+# Add Bitnami repository if not already added
+echo "📦 Adding Bitnami Helm repository..."
+helm repo add bitnami https://charts.bitnami.com/bitnami || true
+helm repo update
+
+# Deploy or upgrade RabbitMQ only
+echo "🔧 Deploying RabbitMQ..."
+helm upgrade --install lifepuzzle-rabbitmq ./lifepuzzle-infrastructure \
+    --namespace lifepuzzle \
+    --create-namespace \
+    --values ./lifepuzzle-infrastructure/values-prod.yaml \
+    --set mysql.enabled=false \
+    --set rabbitmq.enabled=true \
+    --set rabbitmq.auth.password="$RABBITMQ_PASSWORD" \
+    --set rabbitmq.auth.erlangCookie="$RABBITMQ_ERLANG_COOKIE" \
+    --wait \
+    --timeout=10m
+
+echo "✅ RabbitMQ deployment completed successfully!"
+
+# Show deployment status
+echo "📊 RabbitMQ Deployment Status:"
+helm status lifepuzzle-rabbitmq -n lifepuzzle
+
+echo ""
+echo "🔍 RabbitMQ Pod Status:"
+kubectl get pods -n lifepuzzle -l app.kubernetes.io/name=rabbitmq
+
+echo ""
+echo "🌐 RabbitMQ Service Status:"
+kubectl get svc -n lifepuzzle -l app.kubernetes.io/name=rabbitmq
+
+echo ""
+echo "💡 Next Steps:"
+echo "1. Verify RabbitMQ pod is running: kubectl get pods -n lifepuzzle -l app.kubernetes.io/name=rabbitmq"
+echo "2. Check RabbitMQ logs: kubectl logs -f <rabbitmq-pod-name> -n lifepuzzle"
+echo "3. Access RabbitMQ Management UI:"
+echo "   kubectl port-forward svc/lifepuzzle-rabbitmq 15672:15672 -n lifepuzzle"
+echo "   Then open http://localhost:15672 (user: user, password: \$RABBITMQ_PASSWORD)"


### PR DESCRIPTION
## 작업 배경
- 현재 Helm 배포 스크립트는 MySQL과 RabbitMQ를 함께 배포하는 방식만 지원
- 개발/운영 환경에서 필요에 따라 개별 컴포넌트만 배포하고 싶은 요구사항
- 인프라 컴포넌트별로 독립적인 배포 및 관리 필요

## 작업 내용
- MySQL 전용 배포 스크립트 추가 (`deploy-mysql-prod.sh`)
  - MySQL 관련 환경변수만 체크
  - `lifepuzzle-mysql` 릴리스명 사용
  - MySQL 전용 상태 확인 및 가이드 제공
- RabbitMQ 전용 배포 스크립트 추가 (`deploy-rabbitmq-prod.sh`)
  - RabbitMQ 관련 환경변수만 체크
  - `lifepuzzle-rabbitmq` 릴리스명 사용
  - RabbitMQ 전용 상태 확인 및 가이드 제공
- 기존 `deploy-prod.sh` 업데이트
  - 전체 인프라 배포용으로 명시
  - 개별 배포 스크립트 안내 추가
- README.md 업데이트
  - 배포 옵션 섹션 추가
  - Helm 릴리스 정보 테이블 추가
  - 환경변수 설정 가이드 추가

## 참고 사항
- 기존 `deploy-prod.sh` 기능은 변경 없음
- 각 스크립트는 독립적인 Helm 릴리스 생성
- 개별 배포 시에도 동일한 values 파일 사용
- 모든 스크립트에 실행 권한 부여

**배포 옵션:**
- 전체: `./deploy-prod.sh` → `lifepuzzle-infra`
- MySQL만: `./deploy-mysql-prod.sh` → `lifepuzzle-mysql`  
- RabbitMQ만: `./deploy-rabbitmq-prod.sh` → `lifepuzzle-rabbitmq`

🤖 Generated with [Claude Code](https://claude.ai/code)