### PR TITLE
[SHOW] feat: add .env file support for Helm deployment scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,22 @@
 # Copy this file to .env and update the values
 # cp .env.example .env
 
+# ================================
+# Infrastructure Deployment Variables
+# ================================
+# Required for Helm deployment scripts in infra/helm/
+
+# MySQL Configuration for Infrastructure
+MYSQL_ROOT_PASSWORD=your-secure-root-password
+MYSQL_PASSWORD=your-secure-lifepuzzle-password
+
+# RabbitMQ Configuration for Infrastructure
+RABBITMQ_PASSWORD=your-secure-rabbitmq-password
+RABBITMQ_ERLANG_COOKIE=your-secure-erlang-cookie
+
+# ================================
+# Application Configuration
+# ================================
 # Database Configuration
 # For Docker environment
 DB_LOCAL_URL=jdbc:mysql://mysql:3306/lifepuzzle

--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -41,6 +41,26 @@ Required environment variables:
 - `RABBITMQ_ERLANG_COOKIE`
 
 ### Environment Variables Setup
+
+#### Option 1: Using .env file (Recommended)
+1. Copy the example file:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` file in the root directory and update the infrastructure variables:
+   ```bash
+   # Infrastructure Deployment Variables
+   MYSQL_ROOT_PASSWORD=your-secure-root-password
+   MYSQL_PASSWORD=your-secure-lifepuzzle-password
+   RABBITMQ_PASSWORD=your-secure-rabbitmq-password
+   RABBITMQ_ERLANG_COOKIE=your-secure-erlang-cookie
+   ```
+3. Run deployment scripts (they will automatically load the .env file):
+   ```bash
+   ./deploy-prod.sh
+   ```
+
+#### Option 2: Manual export
 ```bash
 # MySQL credentials
 export MYSQL_ROOT_PASSWORD='your-secure-root-password'

--- a/infra/helm/deploy-mysql-prod.sh
+++ b/infra/helm/deploy-mysql-prod.sh
@@ -5,6 +5,13 @@
 
 set -e
 
+# Load environment variables from root .env file if it exists
+ROOT_ENV_FILE="$(cd "$(dirname "$0")/../.." && pwd)/.env"
+if [ -f "$ROOT_ENV_FILE" ]; then
+    echo "📁 Loading environment variables from .env file..."
+    export $(cat "$ROOT_ENV_FILE" | grep -v '^#' | grep -v '^$' | xargs)
+fi
+
 echo "🗄️ Deploying MySQL to Production..."
 
 # Check if required environment variables are set

--- a/infra/helm/deploy-prod.sh
+++ b/infra/helm/deploy-prod.sh
@@ -10,6 +10,13 @@
 
 set -e
 
+# Load environment variables from root .env file if it exists
+ROOT_ENV_FILE="$(cd "$(dirname "$0")/../.." && pwd)/.env"
+if [ -f "$ROOT_ENV_FILE" ]; then
+    echo "📁 Loading environment variables from .env file..."
+    export $(cat "$ROOT_ENV_FILE" | grep -v '^#' | grep -v '^$' | xargs)
+fi
+
 echo "🚀 Deploying Full LifePuzzle Infrastructure to Production..."
 
 # Check if required environment variables are set

--- a/infra/helm/deploy-rabbitmq-prod.sh
+++ b/infra/helm/deploy-rabbitmq-prod.sh
@@ -5,6 +5,13 @@
 
 set -e
 
+# Load environment variables from root .env file if it exists
+ROOT_ENV_FILE="$(cd "$(dirname "$0")/../.." && pwd)/.env"
+if [ -f "$ROOT_ENV_FILE" ]; then
+    echo "📁 Loading environment variables from .env file..."
+    export $(cat "$ROOT_ENV_FILE" | grep -v '^#' | grep -v '^$' | xargs)
+fi
+
 echo "🐰 Deploying RabbitMQ to Production..."
 
 # Check if required environment variables are set


### PR DESCRIPTION
## 작업 배경
- Helm 배포 스크립트가 환경변수를 수동으로 export해야 하는 불편함
- 프로젝트 루트의 .env 파일을 활용해서 배포 관련 환경변수를 통합 관리하고 싶음
- 개발자가 더 쉽게 인프라 배포를 할 수 있도록 개선 필요

## 작업 내용
- 모든 Helm 배포 스크립트에 .env 파일 자동 로딩 기능 추가
  - `deploy-prod.sh`
  - `deploy-mysql-prod.sh` 
  - `deploy-rabbitmq-prod.sh`
- .env.example 파일에 인프라 배포용 환경변수 섹션 추가
  - `MYSQL_ROOT_PASSWORD`
  - `MYSQL_PASSWORD`
  - `RABBITMQ_PASSWORD`
  - `RABBITMQ_ERLANG_COOKIE`
- README.md 업데이트
  - .env 파일 사용법 추가 (Option 1: 추천방법)
  - 기존 manual export 방법도 유지 (Option 2)
- 안전한 .env 파싱
  - 주석(#) 라인 제외
  - 빈 줄 제외
  - 루트 디렉토리 .env 파일 자동 탐지

## 참고 사항
- 기존 수동 환경변수 export 방식과 완전 호환
- .env 파일이 없어도 정상 동작
- 루트 디렉토리의 .env 파일을 자동으로 찾아서 로딩
- 환경변수 검증 로직은 기존과 동일하게 유지

**사용법:**
```bash
# 1. .env 파일 생성
cp .env.example .env

# 2. 인프라 환경변수 설정 (.env 파일에서)
MYSQL_ROOT_PASSWORD=your-password
# ...

# 3. 배포 스크립트 실행 (자동으로 .env 로딩)
./infra/helm/deploy-prod.sh
```

🤖 Generated with [Claude Code](https://claude.ai/code)