### PR TITLE
[SHOW] fix: use proper multi-stage Dockerfile for lifepuzzle-api deployment

### DIFF
--- a/.github/workflows/deploy-lifepuzzle-api.yml
+++ b/.github/workflows/deploy-lifepuzzle-api.yml
@@ -51,9 +51,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ./services/lifepuzzle-api/Dockerfile
           push: true
-          build-args: |
-            JAR_PATH=${{ env.artifact }}
           tags: ${{ secrets.GHCR_LIFEPUZZLE_API }}:latest
 
       - name: SSH into Home Server and Restart Deployment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM openjdk:21
-
-ARG JAR_PATH=services/lifepuzzle-api/build/libs/lifepuzzle-api-*.jar
-COPY ${JAR_PATH} app.jar
-CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 작업 배경
- lifepuzzle API 배포 시 "Invalid or corrupt jarfile app.jar" 오류 발생
- 현재 GitHub Actions에서 사용하는 root Dockerfile이 너무 단순하여 JAR 파일 손상 문제 야기
- services/lifepuzzle-api/Dockerfile은 더 안전하고 완성도 높은 멀티스테이지 빌드 제공

## 작업 내용
- GitHub Actions 워크플로우를 services/lifepuzzle-api/Dockerfile 사용하도록 수정
- 불필요한 root Dockerfile 제거
- JAR_PATH 빌드 인자 제거 (멀티스테이지 빌드에서 불필요)

## 참고 사항
- 멀티스테이지 빌드로 보안 강화 (비루트 사용자 실행)
- Health check 포함으로 배포 안정성 향상
- Eclipse Temurin 21 사용으로 최적화된 JRE 이미지 적용

🤖 Generated with [Claude Code](https://claude.ai/code)