### PR TITLE
[SHOW][LP-468] fix: add missing environment variables for image-resizer deployment

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -65,6 +65,17 @@ jobs:
               --set secrets.awsAccessKey="${{ secrets.AWS_ACCESS_KEY }}" \
               --set secrets.awsSecretKey="${{ secrets.AWS_SECRET_KEY }}" \
               --set secrets.awsS3Bucket="${{ secrets.AWS_S3_BUCKET }}" \
+              --set env.DB_HOST="${{ secrets.DB_HOST }}" \
+              --set env.DB_PORT="${{ secrets.DB_PORT }}" \
+              --set env.DB_NAME="${{ secrets.DB_NAME }}" \
+              --set env.DB_USER="${{ secrets.DB_USER }}" \
+              --set env.RABBITMQ_HOST="${{ secrets.RABBITMQ_HOST }}" \
+              --set env.RABBITMQ_PORT="${{ secrets.RABBITMQ_PORT }}" \
+              --set env.RABBITMQ_USER="${{ secrets.RABBITMQ_USER }}" \
+              --set env.RABBITMQ_VHOST="${{ secrets.RABBITMQ_VHOST }}" \
+              --set env.AWS_REGION="${{ secrets.AWS_REGION }}" \
+              --set env.PORT="9000" \
+              --set env.QUEUE_NAME="image-resize-queue" \
               --set image.tag="latest" \
               --wait \
               --timeout=10m


### PR DESCRIPTION
## 작업 배경
- image-resizer 서비스 배포 시 환경 변수가 누락되어 연결 실패 가능성
- Helm template에서 참조하는 환경 변수들이 GitHub Actions에서 전달되지 않음
- DB, RabbitMQ, AWS 연결에 필요한 필수 환경 변수들이 설정되지 않음

## 작업 내용
- DB 연결을 위한 환경 변수 추가 (DB_HOST, DB_PORT, DB_NAME, DB_USER)
- RabbitMQ 연결을 위한 환경 변수 추가 (RABBITMQ_HOST, RABBITMQ_PORT, RABBITMQ_USER, RABBITMQ_VHOST)
- AWS S3 연결을 위한 AWS_REGION 환경 변수 추가
- 애플리케이션 설정을 위한 PORT, QUEUE_NAME 기본값 설정

## 참고 사항
- GitHub Secrets에서 값을 가져와 Helm --set 옵션으로 전달
- 기존 secrets(패스워드류)는 유지하고 connection 정보만 추가
- Go 애플리케이션의 config.go에서 참조하는 모든 환경 변수 포함

🤖 Generated with [Claude Code](https://claude.ai/code)