### PR TITLE
[SHOW][LP-468] fix: correct SSH deployment path for image-resizer

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -52,7 +52,7 @@ jobs:
           port: ${{ secrets.HOME_SERVER_PORT }}
           script: |
             echo "Deploying image-resizer with Helm..."
-            cd /path/to/lifepuzzle-backend/infra/helm
+            cd ~/workspace/lifepuzzle-backend/infra/helm
             /opt/homebrew/bin/kubectl config use-context prod-app
             
             # Deploy image-resizer using Helm


### PR DESCRIPTION
## 작업 배경
- image-resizer 배포 시 SSH 스크립트에서 잘못된 경로 사용
- 현재 `/path/to/lifepuzzle-backend`로 하드코딩되어 있어 디렉토리를 찾을 수 없음
- 실제 홈 서버의 디렉토리 구조와 일치하지 않아 배포 실패

## 작업 내용
- SSH 스크립트의 경로를 `/path/to/lifepuzzle-backend`에서 `~/workspace/lifepuzzle-backend`로 수정
- Helm 배포가 올바른 디렉토리에서 실행되도록 보장
- 홈 서버의 실제 디렉토리 구조에 맞춤

## 참고 사항
- 단순한 경로 수정이지만 배포 성공을 위해 필수적
- 다른 배포 스크립트들과 일관성 유지
- SSH 접속 후 cd 명령이 정상적으로 작동하도록 함

🤖 Generated with [Claude Code](https://claude.ai/code)