### PR TITLE
[SHOW] fix: use configurable workspace dir in deploy-image-resizer workflow

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -52,7 +52,7 @@ jobs:
           port: ${{ secrets.HOME_SERVER_PORT }}
           script: |
             echo "Deploying image-resizer with Helm..."
-            cd ~/workspace/lifepuzzle-backend/infra/helm
+            cd ${{ secrets.HOME_SERVER_WORKSPACE_DIR }}/lifepuzzle-backend/infra/helm
             /opt/homebrew/bin/kubectl config use-context prod-app
             
             # Deploy image-resizer using Helm


### PR DESCRIPTION
## 작업 배경
- deploy-image-resizer.yml 워크플로우에서 하드코딩된 ~/workspace 경로로 인한 경로 해결 문제
- 서버 환경에 따라 workspace 디렉토리 위치가 달라질 수 있어 유연한 설정 필요

## 작업 내용
- 하드코딩된 `~/workspace` 경로를 `secrets.HOME_SERVER_WORKSPACE_DIR` 시크릿으로 대체
- 서버 환경에 따른 유연한 workspace 디렉토리 설정 가능
- 경로 해결 이슈 수정

## 참고 사항
- `HOME_SERVER_WORKSPACE_DIR` 시크릿에는 workspace 디렉토리까지의 경로를 설정해야 함
- 예: `/Users/username/workspace` (workspace 디렉토리까지만)

🤖 Generated with [Claude Code](https://claude.ai/code)