### PR TITLE
[SHOW][LP-468] fix: add git pull step in deploy-image-resizer workflow

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -52,7 +52,9 @@ jobs:
           port: ${{ secrets.HOME_SERVER_PORT }}
           script: |
             echo "Deploying image-resizer with Helm..."
-            cd ${{ secrets.HOME_SERVER_WORKSPACE_DIR }}/lifepuzzle-backend/infra/helm
+            cd ${{ secrets.HOME_SERVER_WORKSPACE_DIR }}/lifepuzzle-backend
+            git pull origin main
+            cd infra/helm
             /opt/homebrew/bin/kubectl config use-context prod-app
             
             # Deploy image-resizer using Helm


### PR DESCRIPTION
## 작업 배경
- deploy-image-resizer 워크플로우에서 서버의 outdated 코드로 인한 배포 이슈 발생
- SSH 서버에서 git pull이 실행되지 않아 최신 helm chart나 설정 파일이 반영되지 않는 문제

## 작업 내용
- 배포 전에 `git pull origin main` 단계 추가
- 서버의 코드가 최신 상태임을 보장
- helm chart와 설정 파일이 최신 버전으로 업데이트됨

## 참고 사항
- 이제 워크플로우 실행 시 자동으로 서버 코드가 최신으로 업데이트됨
- 배포 전 코드 동기화로 인한 안정성 향상

🤖 Generated with [Claude Code](https://claude.ai/code)