### PR TITLE
[SHOW][LP-468] fix: add GHCR authentication and imagePullSecrets for image-resizer

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -57,11 +57,23 @@ jobs:
             cd infra/helm
             /opt/homebrew/bin/kubectl config use-context prod-app
             
+            # Create or update GHCR pull secret
+            /opt/homebrew/bin/kubectl create secret docker-registry ghcr-secret \
+              --docker-server=ghcr.io \
+              --docker-username=${{ github.actor }} \
+              --docker-password=${{ secrets.GITHUB_TOKEN }} \
+              --namespace=lifepuzzle \
+              --dry-run=client -o yaml | /opt/homebrew/bin/kubectl apply -f -
+            
             # Deploy image-resizer using Helm
             /opt/homebrew/bin/helm upgrade --install lifepuzzle-image-resizer ./lifepuzzle-image-resizer \
               --namespace lifepuzzle \
               --create-namespace \
               --values ./lifepuzzle-image-resizer/values-prod.yaml \
+              --set image.repository="${{ secrets.GHCR_IMAGE_RESIZER }}" \
+              --set image.tag="latest" \
+              --set image.pullPolicy="Always" \
+              --set imagePullSecrets[0].name="ghcr-secret" \
               --set secrets.dbPassword="${{ secrets.MYSQL_PASSWORD }}" \
               --set secrets.rabbitmqPassword="${{ secrets.RABBITMQ_PASSWORD }}" \
               --set secrets.awsAccessKey="${{ secrets.AWS_ACCESS_KEY }}" \
@@ -78,7 +90,6 @@ jobs:
               --set env.AWS_REGION="${{ secrets.AWS_REGION }}" \
               --set env.PORT="9000" \
               --set env.QUEUE_NAME="image-resize-queue" \
-              --set image.tag="latest" \
               --wait \
               --timeout=10m
             


### PR DESCRIPTION
## 작업 배경
- deploy-image-resizer 워크플로우에서 "image can't be pulled" 에러 발생
- GHCR(GitHub Container Registry)에서 프라이빗 이미지 pull 시 인증 문제
- imagePullSecrets 설정 누락으로 인한 이미지 다운로드 실패

## 작업 내용
- GHCR 인증을 위한 `ghcr-secret` 생성 로직 추가
- GitHub 토큰을 사용한 Docker registry 시크릿 생성
- Helm 배포 시 `imagePullSecrets` 설정 추가
- 정확한 이미지 레지스트리 경로 설정 (`secrets.GHCR_IMAGE_RESIZER` 사용)
- 이미지 pull 정책을 "Always"로 설정하여 최신 이미지 보장

## 참고 사항
- 이제 Kubernetes 클러스터에서 GHCR 프라이빗 이미지를 정상적으로 pull 가능
- 워크플로우 실행 시마다 인증 시크릿이 자동 업데이트됨

🤖 Generated with [Claude Code](https://claude.ai/code)