### PR TITLE
[SHOW][LP-468] fix: escape imagePullSecrets syntax for zsh compatibility

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -73,7 +73,7 @@ jobs:
               --set image.repository="${{ secrets.GHCR_IMAGE_RESIZER }}" \
               --set image.tag="latest" \
               --set image.pullPolicy="Always" \
-              --set imagePullSecrets[0].name="ghcr-secret" \
+              --set "imagePullSecrets[0].name=ghcr-secret" \
               --set secrets.dbPassword="${{ secrets.MYSQL_PASSWORD }}" \
               --set secrets.rabbitmqPassword="${{ secrets.RABBITMQ_PASSWORD }}" \
               --set secrets.awsAccessKey="${{ secrets.AWS_ACCESS_KEY }}" \


### PR DESCRIPTION
## 작업 배경
- deploy-image-resizer 워크플로우에서 `zsh:16: no matches found: imagePullSecrets[0].name=ghcr-secret` 에러 발생
- zsh에서 대괄호(`[]`)가 glob 패턴으로 해석되어 오류 발생
- SSH 실행 환경에서 zsh 사용 시 Helm 파라미터 전달 실패

## 작업 내용
- `imagePullSecrets[0].name=ghcr-secret`를 따옴표로 감싸서 zsh glob 확장 방지
- `--set "imagePullSecrets[0].name=ghcr-secret"`로 수정하여 올바른 파라미터 전달 보장
- zsh 및 bash 양쪽에서 호환되는 안전한 구문 사용

## 참고 사항
- 이제 zsh 환경에서도 Helm 배포가 정상적으로 작동
- imagePullSecrets 설정이 올바르게 적용되어 GHCR 이미지 pull 가능

🤖 Generated with [Claude Code](https://claude.ai/code)