### PR TITLE
refactor: remove automated ghcr-secret creation from workflow

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -63,17 +63,6 @@ jobs:
             echo "Expected full image: ${{ secrets.GHCR_IMAGE_RESIZER }}:latest"
             echo "GitHub Actor: ${{ github.actor }}"
             
-            # Create or update GHCR pull secret
-            /opt/homebrew/bin/kubectl create secret docker-registry ghcr-secret \
-              --docker-server=ghcr.io \
-              --docker-username=${{ github.actor }} \
-              --docker-password=${{ secrets.GITHUB_TOKEN }} \
-              --namespace=lifepuzzle \
-              --dry-run=client -o yaml | /opt/homebrew/bin/kubectl apply -f -
-            
-            # Debug: Check if secret was created
-            /opt/homebrew/bin/kubectl get secret ghcr-secret -n lifepuzzle -o yaml
-            
             # Deploy image-resizer using Helm
             /opt/homebrew/bin/helm upgrade --install lifepuzzle-image-resizer ./lifepuzzle-image-resizer \
               --namespace lifepuzzle \


### PR DESCRIPTION
## 작업 배경
- ghcr-secret 설정을 수동으로 관리하기로 결정
- 워크플로우에서 자동으로 생성하는 kubectl 명령어들이 불필요
- 배포 과정을 단순화하고 수동 설정된 시크릿 사용

## 작업 내용
- **자동 시크릿 생성 제거**: kubectl로 ghcr-secret을 생성하는 명령어 삭제
- **시크릿 검증 로직 제거**: ghcr-secret YAML 출력 명령어 삭제
- **imagePullSecrets 설정 유지**: Helm에서 ghcr-secret 참조는 그대로 유지
- **디버깅 정보 유지**: 이미지 정보 및 배포 후 상태 확인 로직은 보존

## 변경 사항
- 수동으로 설정된 `ghcr-secret`을 전제로 한 워크플로우
- 배포 과정에서 불필요한 kubectl 명령어 제거
- 더 간단하고 안정적인 배포 프로세스

## 참고 사항
- `ghcr-secret`은 클러스터에 미리 수동 설정되어 있어야 함
- 디버깅 정보는 여전히 출력되어 문제 진단 가능

🤖 Generated with [Claude Code](https://claude.ai/code)