### PR TITLE
[SHOW][LP-468] fix: add executable permission to image-resizer binary and correct port

### DIFF
--- a/services/image-resizer/Dockerfile
+++ b/services/image-resizer/Dockerfile
@@ -25,12 +25,13 @@ RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
 
 COPY --from=builder --chown=appuser:appgroup /app/services/image-resizer/main .
+RUN chmod +x main
 
 # Switch to non-root user
 USER appuser
 
 # Expose port
-EXPOSE 900
+EXPOSE 9000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \


### PR DESCRIPTION
## 작업 배경
- image-resizer 컨테이너 실행 시 "permission denied" 에러 발생
- OCI runtime create 실패로 인한 컨테이너 시작 불가
- EXPOSE 포트가 잘못 설정되어 있음

## 작업 내용
- **실행 권한 추가**: `RUN chmod +x main` 명령어 추가하여 바이너리 실행 권한 부여
- **포트 수정**: EXPOSE 포트를 900에서 9000으로 수정하여 애플리케이션 포트와 일치
- **컨테이너 시작 문제 해결**: exec "./main" permission denied 에러 해결

## 기술적 배경
- Go 바이너리가 Alpine 이미지로 복사될 때 실행 권한이 유지되지 않음
- COPY 명령어는 파일 권한을 완전히 보존하지 않을 수 있음
- chmod +x로 명시적으로 실행 권한을 부여해야 함

## 참고 사항
- 이제 컨테이너가 정상적으로 시작되고 ./main 바이너리가 실행됨
- 포트 9000으로 애플리케이션에 접근 가능

🤖 Generated with [Claude Code](https://claude.ai/code)