### PR TITLE
[SHOW][LP-468] fix: improve binary permissions and static linking in Dockerfile

### DIFF
--- a/services/image-resizer/Dockerfile
+++ b/services/image-resizer/Dockerfile
@@ -12,20 +12,22 @@ COPY services/image-resizer ./services/image-resizer
 WORKDIR /app/services/image-resizer
 
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o main .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o main .
+RUN chmod +x main
 
 FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates wget
 
-WORKDIR /root/
+WORKDIR /app
 
-# Create non-root user
+# Copy binary with execute permissions
+COPY --from=builder --chmod=755 /app/services/image-resizer/main ./main
+
+# Create non-root user and change ownership
 RUN addgroup -g 1001 -S appgroup && \
-    adduser -u 1001 -S appuser -G appgroup
-
-COPY --from=builder --chown=appuser:appgroup /app/services/image-resizer/main .
-RUN chmod +x main
+    adduser -u 1001 -S appuser -G appgroup && \
+    chown appuser:appgroup ./main
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
## 작업 배경
- image-resizer 컨테이너에서 지속적인 "permission denied" 에러 발생
- OCI runtime create 실패로 인한 컨테이너 시작 불가
- 기존 권한 설정 방법이 효과적이지 않음

## 작업 내용
- **명시적 권한 설정**: `COPY --chmod=755` 사용하여 복사와 동시에 실행 권한 부여
- **Static linking 개선**: Go 빌드에 `-ldflags '-extldflags "-static"'` 추가
- **빌더 단계에서 권한 설정**: `chmod +x` 를 빌드 단계에서 미리 실행
- **작업 디렉토리 변경**: `/root`에서 `/app`으로 변경하여 보안 향상
- **소유권 관리 개선**: 권한 설정 후 non-root 사용자로 소유권 이전

## 기술적 개선사항
1. **Docker COPY --chmod**: Docker 20.10+ 기능으로 복사와 동시에 권한 설정
2. **정적 링킹**: 더 나은 호환성을 위한 완전한 정적 바이너리 생성
3. **권한 순서**: root 권한으로 모든 권한 설정 완료 후 user 전환
4. **명시적 소유권**: chown으로 파일 소유권을 명확히 설정

## 참고 사항
- 이제 바이너리가 확실히 실행 가능한 상태로 컨테이너에 배치됨
- permission denied 에러가 완전히 해결될 것으로 예상

🤖 Generated with [Claude Code](https://claude.ai/code)