### PR TITLE
fix: build RabbitMQ URL from individual environment variables

### DIFF
--- a/services/image-resizer/config/config.go
+++ b/services/image-resizer/config/config.go
@@ -30,9 +30,24 @@ func Load() (*Config, error) {
 		databaseURL = dbUser + ":" + dbPassword + "@tcp(" + dbHost + ":" + dbPort + ")/" + dbName
 	}
 
+	// Build RabbitMQ URL from individual components if RABBITMQ_URL not provided
+	rabbitmqURL := getEnv("RABBITMQ_URL", "")
+	if rabbitmqURL == "" {
+		rabbitmqHost := getEnv("RABBITMQ_HOST", "localhost")
+		rabbitmqPort := getEnv("RABBITMQ_PORT", "5672")
+		rabbitmqUser := getEnv("RABBITMQ_USER", "guest")
+		rabbitmqPassword := getEnv("RABBITMQ_PASSWORD", "guest")
+		rabbitmqVHost := getEnv("RABBITMQ_VHOST", "")
+		if rabbitmqVHost != "" && rabbitmqVHost != "/" {
+			rabbitmqURL = "amqp://" + rabbitmqUser + ":" + rabbitmqPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/" + rabbitmqVHost
+		} else {
+			rabbitmqURL = "amqp://" + rabbitmqUser + ":" + rabbitmqPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/"
+		}
+	}
+
 	return &Config{
 		DatabaseURL:      databaseURL,
-		RabbitMQURL:      getEnv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/"),
+		RabbitMQURL:      rabbitmqURL,
 		AWSRegion:        getEnv("AWS_REGION", "us-east-1"),
 		S3Bucket:         getEnvWithFallback("S3_BUCKET", "AWS_S3_BUCKET", "lifepuzzle-images"),
 		AWSAccessKeyID:   getEnvWithFallback("AWS_ACCESS_KEY_ID", "AWS_ACCESS_KEY", ""),


### PR DESCRIPTION
## 작업 배경
- image-resizer에서 RabbitMQ 연결 시 localhost로 연결을 시도하는 문제 발생
- 환경 변수 `RABBITMQ_HOST=lifepuzzle-rabbitmq`로 설정했지만 `[::1]:5672`로 연결 시도
- Go 코드에서 `RABBITMQ_URL` 환경 변수만 확인하고 개별 변수들을 무시

## 문제 분석
현재 Go 코드의 문제점:
```go
RabbitMQURL: getEnv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
```
- `RABBITMQ_URL`이 없으면 기본값 localhost 사용
- Helm에서는 `RABBITMQ_HOST`, `RABBITMQ_PORT` 등 개별 환경 변수만 설정
- 개별 환경 변수들을 조합하여 URL을 구성하는 로직 누락

## 작업 내용
- **URL 구성 로직 추가**: 개별 환경 변수들로부터 RabbitMQ URL 생성
- **환경 변수 매핑**: 
  - `RABBITMQ_HOST` → 호스트명
  - `RABBITMQ_PORT` → 포트
  - `RABBITMQ_USER` → 사용자명
  - `RABBITMQ_PASSWORD` → 패스워드
  - `RABBITMQ_VHOST` → 가상 호스트
- **VHost 처리**: 빈 값이거나 "/" 일 때 적절한 URL 형식 생성
- **하위 호환성**: 기존 `RABBITMQ_URL` 설정도 계속 지원

## 예상 결과
이제 다음과 같은 URL이 생성됩니다:
```
amqp://lifepuzzle:password@lifepuzzle-rabbitmq:5672/lifepuzzle
```

## 참고 사항
- Kubernetes 서비스 이름으로 정상적인 RabbitMQ 연결 가능
- localhost 연결 시도 문제 완전 해결

🤖 Generated with [Claude Code](https://claude.ai/code)