### PR TITLE
[SHOW][LP-468] chore: add RabbitMQ URL construction logging

### DIFF
--- a/services/image-resizer/config/config.go
+++ b/services/image-resizer/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -38,11 +39,18 @@ func Load() (*Config, error) {
 		rabbitmqUser := getEnv("RABBITMQ_USER", "guest")
 		rabbitmqPassword := getEnv("RABBITMQ_PASSWORD", "guest")
 		rabbitmqVHost := getEnv("RABBITMQ_VHOST", "")
+		
+		// Debug logging
+		fmt.Printf("RabbitMQ Config: Host=%s, Port=%s, User=%s, VHost=%s\n", 
+			rabbitmqHost, rabbitmqPort, rabbitmqUser, rabbitmqVHost)
+		
 		if rabbitmqVHost != "" && rabbitmqVHost != "/" {
 			rabbitmqURL = "amqp://" + rabbitmqUser + ":" + rabbitmqPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/" + rabbitmqVHost
 		} else {
 			rabbitmqURL = "amqp://" + rabbitmqUser + ":" + rabbitmqPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/"
 		}
+		
+		fmt.Printf("Generated RabbitMQ URL: %s\n", rabbitmqURL)
 	}
 
 	return &Config{


### PR DESCRIPTION
## 작업 배경
- RabbitMQ URL 파싱 에러 발생: `parse "amqp://lifepuzzle:LpRmq2024": invalid port ":LpRmq2024" after host`
- `amqp://lifepuzzle:LpRmq2024` 형태에서 호스트/포트 부분이 누락되어 패스워드가 포트로 인식됨
- 환경 변수 설정 상태와 URL 구성 과정 디버깅 필요

## 작업 내용
- **환경 변수 로깅**: 개별 RabbitMQ 환경 변수 값들을 출력
  - `RABBITMQ_HOST`, `RABBITMQ_PORT`, `RABBITMQ_USER`, `RABBITMQ_VHOST`
- **최종 URL 로깅**: 생성된 RabbitMQ URL 전체를 출력
- **임시 디버깅**: 문제 해결 후 제거 예정

## 예상 진단 결과
다음 중 하나의 문제가 예상됩니다:
1. `RABBITMQ_HOST` 환경 변수가 비어있음 → `localhost` 사용
2. `RABBITMQ_PORT` 환경 변수가 비어있음 → `5672` 사용  
3. 환경 변수는 설정되었지만 빈 문자열로 전달됨
4. URL 구성 로직에 버그가 있음

## 로그 출력 예시
정상적인 경우:
```
RabbitMQ Config: Host=lifepuzzle-rabbitmq, Port=5672, User=lifepuzzle, VHost=lifepuzzle
Generated RabbitMQ URL: amqp://lifepuzzle:password@lifepuzzle-rabbitmq:5672/lifepuzzle
```

문제가 있는 경우:
```
RabbitMQ Config: Host=, Port=, User=lifepuzzle, VHost=lifepuzzle  
Generated RabbitMQ URL: amqp://lifepuzzle:password@:/ 
```

## 참고 사항
- 이는 임시 디버깅 PR로, 문제 해결 후 로깅 코드는 제거됩니다

🤖 Generated with [Claude Code](https://claude.ai/code)