### PR TITLE
fix: URL encode RabbitMQ credentials to handle special characters

### DIFF
--- a/services/image-resizer/config/config.go
+++ b/services/image-resizer/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -44,10 +45,14 @@ func Load() (*Config, error) {
 		fmt.Printf("RabbitMQ Config: Host=%s, Port=%s, User=%s, VHost=%s\n", 
 			rabbitmqHost, rabbitmqPort, rabbitmqUser, rabbitmqVHost)
 		
+		// URL encode credentials to handle special characters
+		encodedUser := url.QueryEscape(rabbitmqUser)
+		encodedPassword := url.QueryEscape(rabbitmqPassword)
+		
 		if rabbitmqVHost != "" && rabbitmqVHost != "/" {
-			rabbitmqURL = "amqp://" + rabbitmqUser + ":" + rabbitmqPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/" + rabbitmqVHost
+			rabbitmqURL = "amqp://" + encodedUser + ":" + encodedPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/" + rabbitmqVHost
 		} else {
-			rabbitmqURL = "amqp://" + rabbitmqUser + ":" + rabbitmqPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/"
+			rabbitmqURL = "amqp://" + encodedUser + ":" + encodedPassword + "@" + rabbitmqHost + ":" + rabbitmqPort + "/"
 		}
 		
 		fmt.Printf("Generated RabbitMQ URL: %s\n", rabbitmqURL)


### PR DESCRIPTION
## 작업 배경
- RabbitMQ URL 파싱 에러 발생: `parse "amqp://lifepuzzle:LpRmq2024": invalid port ":LpRmq2024" after host`
- 패스워드에 특수 문자 `#` 포함: `LpRmq2024#Secure!`
- AMQP URL에서 `#` 문자는 URL fragment identifier로 해석되어 파싱 오류 발생

## 문제 분석
**원래 URL:**
```
amqp://lifepuzzle:LpRmq2024#Secure!@lifepuzzle-rabbitmq:5672/lifepuzzle
```

**URL 파서가 인식하는 것:**
- Base URL: `amqp://lifepuzzle:LpRmq2024`
- Fragment: `#Secure!@lifepuzzle-rabbitmq:5672/lifepuzzle`
- 결과: 호스트와 포트 부분이 누락되어 파싱 실패

## 작업 내용
- **URL 인코딩 추가**: `url.QueryEscape()` 사용하여 사용자명과 패스워드 인코딩
- **특수 문자 처리**: `#`, `@`, `:`, `!` 등 URL에서 특별한 의미를 가진 문자들을 안전하게 처리
- **인코딩된 자격 증명**: 
  - `lifepuzzle` → `lifepuzzle` (변화 없음)
  - `LpRmq2024#Secure!` → `LpRmq2024%23Secure%21`

## 결과 예상
**Before:**
```
amqp://lifepuzzle:LpRmq2024#Secure!@lifepuzzle-rabbitmq:5672/lifepuzzle  // 파싱 실패
```

**After:**
```
amqp://lifepuzzle:LpRmq2024%23Secure%21@lifepuzzle-rabbitmq:5672/lifepuzzle  // 정상 파싱
```

## 참고 사항
- 이제 패스워드에 특수 문자가 포함되어도 안전하게 처리됨
- RabbitMQ 연결이 정상적으로 이루어질 것으로 예상
- 디버그 로그는 여전히 유지되어 결과 확인 가능

🤖 Generated with [Claude Code](https://claude.ai/code)