### PR TITLE
[SHOW][LP-468] fix: update Dockerfile to support WebP CGO dependencies

### DIFF
--- a/services/image-resizer/Dockerfile
+++ b/services/image-resizer/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.24-alpine AS builder
 
+# Install build dependencies for WebP
+RUN apk add --no-cache gcc musl-dev libwebp-dev
+
 WORKDIR /app
 
 # Copy go workspace files
@@ -12,7 +15,7 @@ COPY services/image-resizer ./services/image-resizer
 WORKDIR /app/services/image-resizer
 
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o main .
+RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o main .
 RUN chmod +x main
 
 FROM alpine:latest


### PR DESCRIPTION
## 작업 배경
- WebP 변환 기능 구현 후 Docker 빌드 시 CGO_ENABLED=0 설정으로 인한 빌드 실패
- WebP 라이브러리(chai2010/webp)가 CGO를 필요로 하여 컴파일 에러 발생

## 작업 내용
- CGO_ENABLED=1로 변경하여 CGO 지원 활성화
- libwebp-dev, gcc, musl-dev 빌드 의존성 추가
- static linking을 위한 빌드 플래그 수정

## 참고 사항
- 이 수정으로 WebP 변환 기능이 Docker 환경에서 정상 작동됨
- 빌드 시간이 약간 증가할 수 있으나 WebP 지원을 위해 필요

PR Guide

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Pn룰을 적극적으로 활용해주세요.
    - _P1: 꼭 반영해주세요 (Request changes)_
        - 보안 취약점, 심각한 버그, 중대한 로직 오류
    - _P2: 적극적으로 고려해주세요 (Request changes)_
        - 성능 이슈, 확장성 문제, 잠재적 버그 가능성
    - _P3: 웬만하면 반영해 주세요 (Comment)_
        - 코드 구조 개선, 테스트 케이스 추가, 예외 처리 보완
    - _P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)_
        - 변수명 개선 제안, 메서드 분리 제안
    - _P5: 사소한 의견입니다 (Approve)_
        - 오타 수정, 들여쓰기/공백 조정, 간단한 코드 스타일 수정
    - _ask: 질문이 있습니다 (Comment)_
        - 코드 이해가 안되는 부분, 구현 의도 파악이 어려운 부분