### PR TITLE
refactor: remove macOS check from Slack notification service

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/slack/SlackService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/slack/SlackService.java
@@ -23,11 +23,9 @@ public class SlackService {
     String[] activeProfiles = environment.getActiveProfiles();
     boolean isLocalProfile = java.util.Arrays.asList(activeProfiles).contains("local");
     boolean isTestProfile = java.util.Arrays.asList(activeProfiles).contains("test");
-    boolean isMacOS = System.getProperty("os.name").toLowerCase().contains("mac");
     
-    if (isLocalProfile || isTestProfile || isMacOS) {
-      log.debug("Slack notification skipped - running in local, test profile: {} or Mac OS: {}",
-          isLocalProfile, isMacOS);
+    if (isLocalProfile || isTestProfile) {
+      log.debug("Slack notification skipped - running in local, test profile");
       log.debug("Message that would have been sent: {}", String.format(format, args));
       return;
     }


### PR DESCRIPTION
## 작업 배경
- SlackService에서 macOS 운영체제 체크로 인해 개발자들의 Mac 환경에서 Slack 알림이 차단되는 문제
- OS 종속적인 로직이 불필요하게 복잡하고 개발 환경을 제한함

## 작업 내용
- macOS 체크 로직 제거로 OS에 관계없이 동작하도록 수정
- local, test 프로필에서만 Slack 알림을 비활성화하는 단순한 조건으로 변경
- 디버그 메시지도 간소화하여 명확성 개선

## 참고 사항
- 이제 개발자의 로컬 Mac 환경에서도 Slack 알림이 정상적으로 작동함
- 프로필 기반 제어가 더 명확하고 관리하기 용이함

🤖 Generated with [Claude Code](https://claude.ai/code)