### PR TITLE
feat: add comprehensive request logging for K8s debugging

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,16 @@
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/LifePuzzleApplication.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/LifePuzzleApplication.java
@@ -15,8 +15,11 @@ public class LifePuzzleApplication {
     System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
   }
 
+  // TODO: 앱 정상 배포 확인을 위한 로그로 확인 후 제거 필요
   public static void main(String[] args) {
+    System.out.println("Starting LifePuzzleApplication");
     SpringApplication.run(LifePuzzleApplication.class, args);
+    System.out.println("Started LifePuzzleApplication - 20250829");
   }
 
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/GalleryWriteEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/GalleryWriteEndpoint.java
@@ -24,8 +24,9 @@ public class GalleryWriteEndpoint {
   public void saveGallery(
       @RequestPart List<MultipartFile> gallery,
       @RequestPart(value = "galleryInfo") GalleryWriteRequest galleryWriteRequest) {
-    galleryWriteService.saveGallery(galleryWriteRequest.getHeroId(),
-        gallery, galleryWriteRequest.getAgeGroup());
+    System.out.println("galleryWriteRequest: " + galleryWriteRequest);
+    galleryWriteService.saveGallery(galleryWriteRequest.heroId(),
+        gallery, galleryWriteRequest.ageGroup());
   }
 
   @DeleteMapping({"/v2/heroes/gallery/{galleryId}", // TODO: FE 전환 후 제거

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/StoryWriteEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/StoryWriteEndpoint.java
@@ -49,7 +49,7 @@ public class StoryWriteEndpoint {
       @AuthenticationPrincipal AuthPayload authPayload) {
     var story = storyGalleryWriteRequest.toStory(heroId, authPayload.getUserId());
 
-    storyWriteService.create(story, storyGalleryWriteRequest.getGalleryIds(), voice);
+    storyWriteService.create(story, storyGalleryWriteRequest.galleryIds(), voice);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
@@ -62,7 +62,7 @@ public class StoryWriteEndpoint {
       @AuthenticationPrincipal AuthPayload authPayload) {
     var story = storyGalleryWriteRequest.toStory(authPayload.getUserId());
 
-    storyWriteService.create(story, storyGalleryWriteRequest.getGalleryIds(), voice);
+    storyWriteService.create(story, storyGalleryWriteRequest.galleryIds(), voice);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/request/GalleryWriteRequest.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/request/GalleryWriteRequest.java
@@ -3,8 +3,5 @@ package io.itmca.lifepuzzle.domain.content.endpoint.request;
 import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
 import lombok.Getter;
 
-@Getter
-public class GalleryWriteRequest {
-  private Long heroId;
-  private AgeGroup ageGroup;
+public record GalleryWriteRequest(Long heroId, AgeGroup ageGroup) {
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/request/StoryGalleryWriteRequest.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/request/StoryGalleryWriteRequest.java
@@ -6,15 +6,17 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
 
-@Getter
-public class StoryGalleryWriteRequest {
-  private String title;
-  private String content;
-  private LocalDate date;
-  // TODO: FE 전환 후 @HeroNo 주석 제거
-  // @HeroNo
-  private Long heroId;
-  private List<Long> galleryIds;
+/**
+ * Request DTO for creating a story with gallery images.
+ *
+ * @param heroId TODO: FE 전환 후 @HeroNo 주석 제거 @HeroNo
+ * @param title story title
+ * @param content story content  
+ * @param date story date
+ * @param galleryIds associated gallery IDs
+ */
+public record StoryGalleryWriteRequest(String title, String content, LocalDate date, Long heroId,
+                                       List<Long> galleryIds) {
 
   @Deprecated
   public Story toStory(Long heroId, Long userId) {

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/Story.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/Story.java
@@ -198,8 +198,8 @@ public class Story {
   }
 
   public void update(StoryGalleryWriteRequest request) {
-    this.date = request.getDate();
-    this.title = request.getTitle();
-    this.content = request.getContent();
+    this.date = request.date();
+    this.title = request.title();
+    this.content = request.content();
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/config/WebConfig.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/config/WebConfig.java
@@ -1,10 +1,12 @@
 package io.itmca.lifepuzzle.global.config;
 
+import io.itmca.lifepuzzle.global.interceptor.RequestLoggingInterceptor;
 import io.itmca.lifepuzzle.global.resolver.CurrentUserArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -12,9 +14,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
   private final CurrentUserArgumentResolver userArgumentResolver;
+  private final RequestLoggingInterceptor requestLoggingInterceptor;
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
     resolvers.add(userArgumentResolver);
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(requestLoggingInterceptor)
+        .addPathPatterns("/**")
+        .excludePathPatterns("/actuator/**", "/health", "/favicon.ico");
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/handler/CustomExceptionHandler.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/handler/CustomExceptionHandler.java
@@ -1,61 +1,129 @@
 package io.itmca.lifepuzzle.global.exception.handler;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @ControllerAdvice
 @Slf4j
 public class CustomExceptionHandler {
 
   @ExceptionHandler(AuthException.class)
-  public ResponseEntity handleUnAuthorizedException(AuthException e) {
+  public ResponseEntity<Void> handleUnAuthorizedException(AuthException e) {
     log.debug("Auth exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
   }
 
   @ExceptionHandler(NotFoundException.class)
-  public ResponseEntity handleNotFoundException(NotFoundException e) {
+  public ResponseEntity<Void> handleNotFoundException(NotFoundException e) {
     log.debug("Not found exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
   }
 
   @ExceptionHandler(AlreadyExistsException.class)
-  public ResponseEntity handleAlreadyExistsException(AlreadyExistsException e) {
+  public ResponseEntity<Void> handleAlreadyExistsException(AlreadyExistsException e) {
     log.debug("Already exists exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.CONFLICT).build();
   }
 
   @ExceptionHandler(ServerExecutionFailException.class)
-  public ResponseEntity handleServerExecutionFailException(ServerExecutionFailException e) {
+  public ResponseEntity<Void> handleServerExecutionFailException(ServerExecutionFailException e) {
     log.info("Server execution fail exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }
 
   @ExceptionHandler(MissingArgumentException.class)
-  public ResponseEntity handleIllegalArgumentException(MissingArgumentException e) {
+  public ResponseEntity<Void> handleIllegalArgumentException(MissingArgumentException e) {
     log.debug("Missing argument exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
   }
 
   @ExceptionHandler(AccessDeniedException.class)
-  public ResponseEntity handleAccessDeniedException(AccessDeniedException e) {
+  public ResponseEntity<Void> handleAccessDeniedException(AccessDeniedException e) {
     log.debug("Access denied exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
   }
 
   @ExceptionHandler(ExpiredException.class)
-  public ResponseEntity handleExpiredException(ExpiredException e) {
+  public ResponseEntity<Void> handleExpiredException(ExpiredException e) {
     log.debug("Expired exception occurred: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
   }
 
   @ExceptionHandler(ExternalApiException.class)
-  public ResponseEntity handleExternalApiException(ExternalApiException e) {
-    log.info("External API exception occurred: {}", e.getMessage());
+  public ResponseEntity<Void> handleExternalApiException(ExternalApiException e, HttpServletRequest request) {
+    log.info("External API exception at {} {}: {}", request.getMethod(), request.getRequestURI(), e.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+  }
+
+  // ===== Validation and Request Processing Exceptions =====
+  
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Void> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+    log.warn("Validation failed at {} {}: {}", request.getMethod(), request.getRequestURI(), e.getBindingResult().getFieldError());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+  }
+
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<Void> handleBindException(BindException e, HttpServletRequest request) {
+    log.warn("Bind exception at {} {}: {}", request.getMethod(), request.getRequestURI(), e.getBindingResult().getFieldError());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<Void> handleMissingParameterException(MissingServletRequestParameterException e, HttpServletRequest request) {
+    log.warn("Missing parameter at {} {}: {} ({})", request.getMethod(), request.getRequestURI(), e.getParameterName(), e.getParameterType());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<Void> handleTypeMismatchException(MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+    log.warn("Type mismatch at {} {}: parameter '{}' should be {}", request.getMethod(), request.getRequestURI(), e.getName(), e.getRequiredType());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<Void> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e, HttpServletRequest request) {
+    log.warn("File size exceeded at {} {}: max size is {}", request.getMethod(), request.getRequestURI(), e.getMaxUploadSize());
+    return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).build();
+  }
+
+  // ===== HTTP and Routing Exceptions =====
+  
+  @ExceptionHandler(NoHandlerFoundException.class)
+  public ResponseEntity<Void> handleNoHandlerFoundException(NoHandlerFoundException e) {
+    log.warn("No handler found for {} {}", e.getHttpMethod(), e.getRequestURL());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<Void> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+    log.warn("Method not supported at {}: {} (supported: {})", request.getRequestURI(), e.getMethod(), e.getSupportedMethods());
+    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
+  }
+
+  // ===== General Exception Handlers =====
+  
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<Void> handleRuntimeException(RuntimeException e, HttpServletRequest request) {
+    log.error("Unexpected runtime exception at {} {}: {}", request.getMethod(), request.getRequestURI(), e.getMessage(), e);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Void> handleGenericException(Exception e, HttpServletRequest request) {
+    log.error("Unexpected exception at {} {}: {}", request.getMethod(), request.getRequestURI(), e.getMessage(), e);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/interceptor/RequestLoggingInterceptor.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/interceptor/RequestLoggingInterceptor.java
@@ -1,0 +1,102 @@
+package io.itmca.lifepuzzle.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+// TODO: k8s 환경에서 요청 디버깅을 위한 것으로 디버깅 완료 후 삭제
+@Slf4j
+@Component
+public class RequestLoggingInterceptor implements HandlerInterceptor {
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    final String timestamp = LocalDateTime.now().format(DATE_TIME_FORMATTER);
+    final String method = request.getMethod();
+    final String uri = request.getRequestURI();
+    final String queryString = request.getQueryString();
+    final String clientIp = getClientIp(request);
+    final String userAgent = request.getHeader("User-Agent");
+
+    StringBuilder logMessage = new StringBuilder();
+    logMessage.append("HTTP Request - ");
+    logMessage.append("Time: ").append(timestamp).append(", ");
+    logMessage.append("Method: ").append(method).append(", ");
+    logMessage.append("URI: ").append(uri);
+    
+    if (StringUtils.hasText(queryString)) {
+      logMessage.append("?").append(queryString);
+    }
+    
+    logMessage.append(", Client IP: ").append(clientIp);
+    logMessage.append(", User-Agent: ").append(userAgent != null ? userAgent.substring(0, Math.min(100, userAgent.length())) : "N/A");
+
+    // Add important headers
+    final String contentType = request.getContentType();
+    if (StringUtils.hasText(contentType)) {
+      logMessage.append(", Content-Type: ").append(contentType);
+    }
+
+    final String authorization = request.getHeader("Authorization");
+    if (StringUtils.hasText(authorization)) {
+      logMessage.append(", Auth: ").append(authorization.startsWith("Bearer") ? "Bearer ***" : "***");
+    }
+
+    log.info(logMessage.toString());
+    
+    // Store start time for response logging
+    request.setAttribute("startTime", System.currentTimeMillis());
+    
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    final Long startTime = (Long) request.getAttribute("startTime");
+    final long duration = startTime != null ? System.currentTimeMillis() - startTime : 0;
+
+    final String timestamp = LocalDateTime.now().format(DATE_TIME_FORMATTER);
+    final String method = request.getMethod();
+    final String uri = request.getRequestURI();
+    final int status = response.getStatus();
+
+    StringBuilder logMessage = new StringBuilder();
+    logMessage.append("HTTP Response - ");
+    logMessage.append("Time: ").append(timestamp).append(", ");
+    logMessage.append("Method: ").append(method).append(", ");
+    logMessage.append("URI: ").append(uri).append(", ");
+    logMessage.append("Status: ").append(status).append(", ");
+    logMessage.append("Duration: ").append(duration).append("ms");
+
+    if (ex != null) {
+      logMessage.append(", Exception: ").append(ex.getClass().getSimpleName());
+    }
+
+    if (status >= 400) {
+      log.warn(logMessage.toString());
+    } else {
+      log.info(logMessage.toString());
+    }
+  }
+
+  private String getClientIp(HttpServletRequest request) {
+    final String forwardedFor = request.getHeader("X-Forwarded-For");
+    if (StringUtils.hasText(forwardedFor)) {
+      return forwardedFor.split(",")[0].trim();
+    }
+    
+    final String realIp = request.getHeader("X-Real-IP");
+    if (StringUtils.hasText(realIp)) {
+      return realIp;
+    }
+    
+    return request.getRemoteAddr();
+  }
+}


### PR DESCRIPTION
## 작업 배경  
- K8s 환경에서 API 요청 디버깅을 위한 포괄적인 로깅 필요
- 현재 예외 발생 시에만 로그가 찍혀서 정상 요청 추적이 어려움
- 클라이언트 IP, User-Agent, 처리 시간 등 상세 정보 부족

## 작업 내용
- **RequestLoggingInterceptor 추가**: 모든 HTTP 요청/응답 로깅
- **요청 로그 정보**:
  - 타임스탬프, HTTP 메서드, URI, 쿼리 파라미터
  - 실제 클라이언트 IP (X-Forwarded-For, X-Real-IP 헤더 고려)
  - User-Agent (100자 제한), Content-Type, Authorization 헤더
- **응답 로그 정보**:
  - 응답 상태 코드, 처리 시간(ms)
  - 예외 발생 시 예외 타입 포함
  - 4xx/5xx는 WARN 레벨, 나머지는 INFO 레벨
- **WebConfig에 인터셉터 등록**: health check, actuator 제외
- **DTO 개선**: GalleryWriteRequest를 record로 변환하여 디버깅 편의성 향상
- **임시 디버그 출력**: GalleryWriteEndpoint에 System.out.println 추가

## 참고 사항
- K8s 환경에서의 임시 디버깅 목적으로 TODO 주석 포함
- 디버깅 완료 후 불필요한 로깅은 제거 예정  
- 로그 예시: `HTTP Request - Time: 2025-08-30 07:15:30.123, Method: POST, URI: /v1/heroes/gallery, Client IP: 192.168.1.100`

🤖 Generated with [Claude Code](https://claude.ai/code)