### PR TITLE
[SHOW][LP-467] feat: unify RABBITMQ_USER to RABBITMQ_USERNAME environment variable

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -83,7 +83,7 @@ jobs:
               --set env.DB_USER="${{ secrets.DB_USER }}" \
               --set env.RABBITMQ_HOST="${{ secrets.RABBITMQ_HOST }}" \
               --set env.RABBITMQ_PORT="${{ secrets.RABBITMQ_PORT }}" \
-              --set env.RABBITMQ_USER="${{ secrets.RABBITMQ_USER }}" \
+              --set env.RABBITMQ_USERNAME="${{ secrets.RABBITMQ_USERNAME }}" \
               --set env.RABBITMQ_VHOST="${{ secrets.RABBITMQ_VHOST }}" \
               --set env.AWS_REGION="${{ secrets.AWS_REGION }}" \
               --set env.PORT="9000" \

--- a/infra/README.md
+++ b/infra/README.md
@@ -266,7 +266,7 @@ DB_PASSWORD=lifepuzzlepass
 # RabbitMQ
 RABBITMQ_HOST=rabbitmq-service.lifepuzzle.svc.cluster.local  # or localhost for Docker
 RABBITMQ_PORT=5672
-RABBITMQ_USER=lifepuzzle
+RABBITMQ_USERNAME=lifepuzzle
 RABBITMQ_PASSWORD=lifepuzzlepass
 RABBITMQ_VHOST=lifepuzzle
 ```

--- a/infra/docker/docker-compose.full.yml
+++ b/infra/docker/docker-compose.full.yml
@@ -72,7 +72,7 @@ services:
       # RabbitMQ configuration
       RABBITMQ_HOST: rabbitmq
       RABBITMQ_PORT: 5672
-      RABBITMQ_USER: lifepuzzle
+      RABBITMQ_USERNAME: lifepuzzle
       RABBITMQ_PASSWORD: lifepuzzlepass
       RABBITMQ_VHOST: lifepuzzle
       

--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -273,7 +273,7 @@ env:
     value: lifepuzzle-infra-rabbitmq.lifepuzzle.svc.cluster.local
   - name: RABBITMQ_PORT
     value: "5672"
-  - name: RABBITMQ_USER
+  - name: RABBITMQ_USERNAME
     value: lifepuzzle
   - name: RABBITMQ_PASSWORD
     valueFrom:

--- a/infra/helm/lifepuzzle-image-resizer/templates/deployment.yaml
+++ b/infra/helm/lifepuzzle-image-resizer/templates/deployment.yaml
@@ -58,8 +58,8 @@ spec:
               value: {{ .Values.env.RABBITMQ_HOST | quote }}
             - name: RABBITMQ_PORT
               value: {{ .Values.env.RABBITMQ_PORT | quote }}
-            - name: RABBITMQ_USER
-              value: {{ .Values.env.RABBITMQ_USER | quote }}
+            - name: RABBITMQ_USERNAME
+              value: {{ .Values.env.RABBITMQ_USERNAME | quote }}
             - name: RABBITMQ_VHOST
               value: {{ .Values.env.RABBITMQ_VHOST | quote }}
             - name: RABBITMQ_PASSWORD

--- a/infra/helm/lifepuzzle-image-resizer/values.yaml
+++ b/infra/helm/lifepuzzle-image-resizer/values.yaml
@@ -76,7 +76,7 @@ env:
   # RabbitMQ configuration
   RABBITMQ_HOST: "lifepuzzle-infra-rabbitmq.lifepuzzle.svc.cluster.local"
   RABBITMQ_PORT: "5672"
-  RABBITMQ_USER: "lifepuzzle"
+  RABBITMQ_USERNAME: "lifepuzzle"
   RABBITMQ_VHOST: "lifepuzzle"
   # RABBITMQ_PASSWORD will be set via secret
   

--- a/infra/helm/lifepuzzle-infrastructure/templates/_helpers.tpl
+++ b/infra/helm/lifepuzzle-infrastructure/templates/_helpers.tpl
@@ -108,7 +108,7 @@ Common environment variables for RabbitMQ
   value: {{ include "lifepuzzle-infrastructure.rabbitmq.serviceName" . }}
 - name: RABBITMQ_PORT
   value: "5672"
-- name: RABBITMQ_USER
+- name: RABBITMQ_USERNAME
   value: {{ .Values.rabbitmq.auth.username }}
 - name: RABBITMQ_PASSWORD
   valueFrom:

--- a/services/image-resizer/config/config.go
+++ b/services/image-resizer/config/config.go
@@ -39,7 +39,7 @@ func Load() (*Config, error) {
 	if rabbitmqURL == "" {
 		rabbitmqHost := getEnv("RABBITMQ_HOST", "localhost")
 		rabbitmqPort := getEnv("RABBITMQ_PORT", "5672")
-		rabbitmqUser := getEnv("RABBITMQ_USER", "guest")
+		rabbitmqUser := getEnv("RABBITMQ_USERNAME", "guest")
 		rabbitmqPassword := getEnv("RABBITMQ_PASSWORD", "guest")
 		rabbitmqVHost := getEnv("RABBITMQ_VHOST", "")
 		


### PR DESCRIPTION
## 작업 배경
- 프로젝트에 RABBITMQ_USERNAME과 RABBITMQ_USER 두 가지 환경 변수가 혼재하여 사용되고 있어 일관성 부족
- 환경 변수 네이밍의 통일성을 위해 RABBITMQ_USERNAME으로 표준화 필요

## 작업 내용
- 모든 RABBITMQ_USER 참조를 RABBITMQ_USERNAME으로 변경
- Go 코드에서 환경 변수명 변경 (services/image-resizer/config/config.go)
- Helm 차트 및 템플릿 업데이트 (values.yaml, deployment.yaml, _helpers.tpl)
- Docker Compose 설정 업데이트 (docker-compose.full.yml)
- GitHub Actions 워크플로우 업데이트 (deploy-image-resizer.yml)
- 관련 문서 업데이트 (README.md)

## 참고 사항
- 환경 변수명 변경으로 인해 배포 시 Secrets 설정 업데이트 필요 (RABBITMQ_USER → RABBITMQ_USERNAME)
- 기존 배포된 환경에서는 새로운 환경 변수명으로 설정 변경 필요

🤖 Generated with [Claude Code](https://claude.ai/code)