### PR TITLE
[SHOW][LP-467] fix: resolve AWS_S3_BUCKET environment variable mismatch in deployment

### DIFF
--- a/infra/helm/lifepuzzle-image-resizer/templates/deployment.yaml
+++ b/infra/helm/lifepuzzle-image-resizer/templates/deployment.yaml
@@ -91,11 +91,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "lifepuzzle-image-resizer.fullname" . }}-secrets
                   key: aws-secret-key
-            - name: S3_BUCKET_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "lifepuzzle-image-resizer.fullname" . }}-secrets
-                  key: aws-s3-bucket
+            - name: AWS_S3_BUCKET
+              value: {{ .Values.env.AWS_S3_BUCKET | quote }}
           
           {{- if .Values.healthCheck.enabled }}
           livenessProbe:

--- a/infra/helm/lifepuzzle-image-resizer/values.yaml
+++ b/infra/helm/lifepuzzle-image-resizer/values.yaml
@@ -86,8 +86,9 @@ env:
   WORKER_COUNT: "4"
   QUEUE_NAME: "image.resize"
   
-  # AWS S3 configuration (will be set via secrets)
+  # AWS S3 configuration
   AWS_REGION: "us-west-2"
+  AWS_S3_BUCKET: "lifepuzzle-images"  # default value, will be overridden by --set
 
 # Secrets configuration
 secrets:

--- a/services/image-resizer/config/config.go
+++ b/services/image-resizer/config/config.go
@@ -64,7 +64,7 @@ func Load() (*Config, error) {
 		DatabaseURL:      databaseURL,
 		RabbitMQURL:      rabbitmqURL,
 		AWSRegion:        getEnv("AWS_REGION", "us-east-1"),
-		S3Bucket:         getEnvWithFallback("S3_BUCKET", "AWS_S3_BUCKET", "lifepuzzle-images"),
+		S3Bucket:         getEnvWithFallback("AWS_S3_BUCKET", "S3_BUCKET", "lifepuzzle-images"),
 		AWSAccessKeyID:   getEnvWithFallback("AWS_ACCESS_KEY_ID", "AWS_ACCESS_KEY", ""),
 		AWSSecretKey:     getEnvWithFallback("AWS_SECRET_ACCESS_KEY", "AWS_SECRET_KEY", ""),
 		QueueName:        getEnv("QUEUE_NAME", "image-resize-queue"),


### PR DESCRIPTION
## 작업 배경
- GitHub Actions에서 `--set env.AWS_S3_BUCKET` 설정했음에도 불구하고 계속 "lifepuzzle-images" 버킷 사용
- 환경 변수명 불일치로 인해 배포 시 의도한 S3 버킷이 적용되지 않는 문제

## 작업 내용
### 환경 변수명 통일
- Helm 템플릿: `S3_BUCKET_NAME` → `AWS_S3_BUCKET`로 변경
- Go config: `AWS_S3_BUCKET`를 우선적으로 확인하도록 순서 변경
- Helm 템플릿에서 secret 대신 env 값 사용하도록 변경

### 배포 플로우 개선  
- Helm values.yaml에 `AWS_S3_BUCKET` 기본값 추가
- GitHub Actions의 `--set env.AWS_S3_BUCKET` 설정이 올바르게 적용되도록 수정
- 환경 변수 우선순위: GitHub Actions `--set` → Helm values → Go config 기본값

## 참고 사항
- 기존 문제: Helm 템플릿 `S3_BUCKET_NAME` ≠ Go 코드 `AWS_S3_BUCKET`/`S3_BUCKET`
- 해결: 모든 컴포넌트에서 `AWS_S3_BUCKET` 환경 변수명 통일
- 이제 GitHub Actions에서 설정한 S3 버킷이 정상적으로 배포에 반영됨

🤖 Generated with [Claude Code](https://claude.ai/code)