### PR TITLE
[SHOW][LP-467] feat: add comprehensive database query logging for debugging

### DIFF
--- a/services/image-resizer/database/database.go
+++ b/services/image-resizer/database/database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -20,6 +21,8 @@ type Database struct {
 }
 
 func NewDatabase(databaseURL string) (*Database, error) {
+	log.Printf("Connecting to database with URL pattern: mysql://[user:password]@[host]/[database]")
+	
 	db, err := sql.Open("mysql", databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
@@ -29,39 +32,64 @@ func NewDatabase(databaseURL string) (*Database, error) {
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
+	log.Printf("Successfully connected to database")
 	return &Database{db: db}, nil
 }
 
 func (d *Database) GetStoryPhoto(id int) (*StoryPhoto, error) {
+	log.Printf("Executing query to get story photo with ID: %d", id)
+	
 	var photo StoryPhoto
 	var resizedSizesJSON []byte
 
 	query := `SELECT id, hero_id, url, resized_sizes FROM story_photo WHERE id = ?`
+	log.Printf("Executing SQL query: %s with parameters: [%d]", query, id)
+	
 	err := d.db.QueryRow(query, id).Scan(&photo.ID, &photo.HeroID, &photo.Url, &resizedSizesJSON)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			log.Printf("No story photo found with ID: %d", id)
+			return nil, fmt.Errorf("story photo with ID %d not found: %w", id, err)
+		}
+		log.Printf("Database query error for photo ID %d: %v", id, err)
 		return nil, fmt.Errorf("failed to get story photo: %w", err)
 	}
 
+	log.Printf("Successfully retrieved photo ID: %d, Hero ID: %d, URL: %s", photo.ID, photo.HeroID, photo.Url)
+
 	if len(resizedSizesJSON) > 0 {
 		if err := json.Unmarshal(resizedSizesJSON, &photo.ResizedSizes); err != nil {
+			log.Printf("Failed to unmarshal resized sizes for photo ID %d: %v", id, err)
 			return nil, fmt.Errorf("failed to unmarshal resized sizes: %w", err)
 		}
+		log.Printf("Photo ID %d has resized sizes: %v", id, photo.ResizedSizes)
+	} else {
+		log.Printf("Photo ID %d has no existing resized sizes", id)
 	}
 
 	return &photo, nil
 }
 
 func (d *Database) UpdateResizedSizes(id int, resizedSizes []int) error {
+	log.Printf("Updating resized sizes for photo ID %d: %v", id, resizedSizes)
+	
 	resizedSizesJSON, err := json.Marshal(resizedSizes)
 	if err != nil {
+		log.Printf("Failed to marshal resized sizes for photo ID %d: %v", id, err)
 		return fmt.Errorf("failed to marshal resized sizes: %w", err)
 	}
 
 	query := `UPDATE story_photo SET resized_sizes = ? WHERE id = ?`
-	_, err = d.db.Exec(query, resizedSizesJSON, id)
+	log.Printf("Executing SQL update: %s with parameters: [%s, %d]", query, string(resizedSizesJSON), id)
+	
+	result, err := d.db.Exec(query, resizedSizesJSON, id)
 	if err != nil {
+		log.Printf("Database update error for photo ID %d: %v", id, err)
 		return fmt.Errorf("failed to update resized sizes: %w", err)
 	}
+
+	rowsAffected, _ := result.RowsAffected()
+	log.Printf("Successfully updated photo ID %d, rows affected: %d", id, rowsAffected)
 
 	return nil
 }


### PR DESCRIPTION
## 작업 배경
- image-resizer 서비스에서 "sql: no rows in result set" 예외가 발생하고 있어 원인 파악이 필요합니다
- 데이터베이스 연결 상태, 실행되는 쿼리, 파라미터 등을 확인할 수 있는 로깅이 부족한 상황입니다
- 디버깅을 위한 상세한 로그가 필요하여 데이터베이스 계층에 포괄적인 로깅을 추가했습니다

## 작업 내용
- 데이터베이스 연결 시 연결 상태 로깅 추가
- GetStoryPhoto 함수에 상세 로깅 추가:
  - 쿼리 실행 전 photo ID 로깅
  - 실제 SQL 쿼리와 파라미터 출력
  - sql.ErrNoRows 구체적 처리 및 로깅
  - 성공 시 조회된 데이터 (ID, Hero ID, URL) 출력
  - resized_sizes 데이터 상태 로깅
- UpdateResizedSizes 함수에 상세 로깅 추가:
  - 업데이트할 데이터 정보 로깅
  - SQL 쿼리와 파라미터 출력
  - 영향받은 행 수 확인 및 로깅

## 참고 사항
- 프로덕션 환경에서 photo ID 729 관련 예외 원인 분석을 위한 임시 로깅 추가
- 디버깅 완료 후 로그 레벨 조정 또는 일부 로그 제거 고려 필요
- 로그를 통해 데이터베이스 연결, 쿼리 실행, 데이터 조회 과정 전체 추적 가능

🤖 Generated with [Claude Code](https://claude.ai/code)