### PR TITLE
[SHOW][LP-467] feat: add HEIC image format support to DecodeImage

### DIFF
--- a/services/image-resizer/go.mod
+++ b/services/image-resizer/go.mod
@@ -3,6 +3,7 @@ module lifepuzzle-backend/services/image-resizer
 go 1.24
 
 require (
+	github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786
 	github.com/aws/aws-sdk-go v1.45.25
 	github.com/chai2010/webp v1.4.0
 	github.com/go-sql-driver/mysql v1.7.1
@@ -12,4 +13,7 @@ require (
 	golang.org/x/image v0.30.0
 )
 
-require github.com/jmespath/go-jmespath v0.4.0 // indirect
+require (
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd // indirect
+)

--- a/services/image-resizer/go.sum
+++ b/services/image-resizer/go.sum
@@ -1,3 +1,5 @@
+github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786 h1:zvgtcRb2B5gynWjm+Fc9oJZPHXwmcgyH0xCcNm6Rmo4=
+github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786/go.mod h1:aKVJoQ0cc9K5Xb058XSnnAxXLliR97qbSqWBlm5ca1E=
 github.com/aws/aws-sdk-go v1.45.25 h1:c4fLlh5sLdK2DCRTY1z0hyuJZU4ygxX8m1FswL6/nF4=
 github.com/aws/aws-sdk-go v1.45.25/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/chai2010/webp v1.4.0 h1:6DA2pkkRUPnbOHvvsmGI3He1hBKf/bkRlniAiSGuEko=
@@ -23,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rabbitmq/amqp091-go v1.9.0 h1:qrQtyzB4H8BQgEuJwhmVQqVHB9O4+MNDJCCAcpc3Aoo=
 github.com/rabbitmq/amqp091-go v1.9.0/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
+github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
+github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/services/image-resizer/resizer/resizer.go
+++ b/services/image-resizer/resizer/resizer.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/adrium/goheif"
 	"github.com/chai2010/webp"
 	"github.com/nfnt/resize"
 	xwebp "golang.org/x/image/webp"
@@ -86,12 +87,20 @@ func (r *ImageResizer) ConvertToWebP(img image.Image) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// DecodeImage decodes an image from bytes, supporting JPEG, PNG, and WebP
+// DecodeImage decodes an image from bytes, supporting JPEG, PNG, WebP, and HEIC
 func (r *ImageResizer) DecodeImage(data []byte) (image.Image, error) {
 	reader := bytes.NewReader(data)
 	
 	// Try to decode as WebP first
 	if img, err := xwebp.Decode(reader); err == nil {
+		return img, nil
+	}
+	
+	// Reset reader
+	reader.Seek(0, 0)
+	
+	// Try to decode as HEIC/HEIF
+	if img, err := goheif.Decode(reader); err == nil {
 		return img, nil
 	}
 	
@@ -111,7 +120,7 @@ func (r *ImageResizer) DecodeImage(data []byte) (image.Image, error) {
 		return img, nil
 	}
 	
-	return nil, fmt.Errorf("unsupported image format")
+	return nil, fmt.Errorf("unsupported image format (supported: JPEG, PNG, WebP, HEIC)")
 }
 
 // ProcessImage converts image to WebP and resizes if necessary


### PR DESCRIPTION
## 작업 배경
- iPhone에서 촬영한 HEIC 포맷 이미지들이 image-resizer 서비스에서 처리되지 않고 있습니다
- 현재 DecodeImage 함수는 JPEG, PNG, WebP만 지원하여 HEIC 이미지 처리 시 "unsupported image format" 오류가 발생합니다
- 모바일에서 많이 사용하는 HEIC 포맷 지원이 필요한 상황입니다

## 작업 내용
- `github.com/adrium/goheif` 라이브러리 추가하여 HEIC/HEIF 디코딩 지원
- DecodeImage 함수에 HEIC 포맷 처리 로직 추가:
  - WebP 다음으로 HEIC 디코딩 시도하도록 순서 조정
  - HEIC 디코딩 실패 시 기존 JPEG, PNG 처리 로직으로 계속 진행
- 에러 메시지 업데이트하여 지원하는 포맷에 HEIC 포함
- go.mod 및 go.sum 파일 업데이트

## 참고 사항
- iPhone 등에서 촬영한 HEIC 이미지를 정상적으로 처리할 수 있게 됨
- 기존 JPEG, PNG, WebP 처리 로직은 변경 없이 유지
- 디코딩 순서: WebP → HEIC → JPEG → PNG 순으로 시도

🤖 Generated with [Claude Code](https://claude.ai/code)