### PR TITLE
fix: force pod replacement in image-resizer deployment

### DIFF
--- a/.github/workflows/deploy-image-resizer.yml
+++ b/.github/workflows/deploy-image-resizer.yml
@@ -41,7 +41,9 @@ jobs:
           context: .
           file: ./services/image-resizer/Dockerfile
           push: true
-          tags: ${{ secrets.GHCR_IMAGE_RESIZER }}:latest
+          tags: |
+            ${{ secrets.GHCR_IMAGE_RESIZER }}:latest
+            ${{ secrets.GHCR_IMAGE_RESIZER }}:${{ steps.current-time.outputs.formattedTime }}
 
       - name: SSH into Home Server and Deploy with Helm
         uses: appleboy/ssh-action@v1.0.3
@@ -60,18 +62,20 @@ jobs:
             # Debug: Check image information
             echo "=== DEBUG: Image Information ==="
             echo "GHCR_IMAGE_RESIZER: ${{ secrets.GHCR_IMAGE_RESIZER }}"
-            echo "Expected full image: ${{ secrets.GHCR_IMAGE_RESIZER }}:latest"
+            echo "Image tag with timestamp: ${{ steps.current-time.outputs.formattedTime }}"
+            echo "Expected full image: ${{ secrets.GHCR_IMAGE_RESIZER }}:${{ steps.current-time.outputs.formattedTime }}"
             echo "GitHub Actor: ${{ github.actor }}"
             
-            # Deploy image-resizer using Helm
+            # Deploy image-resizer using Helm with timestamp tag to force pod replacement
             /opt/homebrew/bin/helm upgrade --install lifepuzzle-image-resizer ./lifepuzzle-image-resizer \
               --namespace lifepuzzle \
               --create-namespace \
               --values ./lifepuzzle-image-resizer/values-prod.yaml \
               --set image.repository="${{ secrets.GHCR_IMAGE_RESIZER }}" \
-              --set image.tag="latest" \
+              --set image.tag="${{ steps.current-time.outputs.formattedTime }}" \
               --set image.pullPolicy="Always" \
               --set "imagePullSecrets[0].name=ghcr-secret" \
+              --set "podAnnotations.deployment\.timestamp=${{ steps.current-time.outputs.formattedTime }}" \
               --set secrets.dbPassword="${{ secrets.DB_PROD_PASSWORD }}" \
               --set secrets.rabbitmqPassword="${{ secrets.RABBITMQ_PASSWORD }}" \
               --set secrets.awsAccessKey="${{ secrets.AWS_ACCESS_KEY }}" \


### PR DESCRIPTION
## 작업 배경
- image-resizer 배포 시 Helm revision은 올라가지만 pod이 교체되지 않는 문제 발생
- `latest` 태그 사용으로 인해 Kubernetes가 새 이미지로 인식하지 않음
- pod template 변경 없이는 새로운 pod 생성되지 않음

## 작업 내용
- 타임스탬프 기반 이미지 태그 사용으로 변경:
  - `latest`와 `YYYY-MM-DDTHH-mm-ss` 형식 태그 모두 빌드/푸시
  - Helm 배포 시 타임스탬프 태그 사용하여 새 이미지 확실히 pull
- Pod template 강제 변경을 위한 annotation 추가:
  - `podAnnotations.deployment.timestamp` 설정으로 pod template 변경 유발
- 디버그 출력 개선하여 실제 배포되는 이미지 태그 확인 가능

## 참고 사항
- 기존 `latest` 태그도 유지하여 호환성 보장
- 타임스탬프 태그로 배포 이력 추적 가능
- Pod replacement가 확실하게 이루어져 새 코드 반영 보장

PR Guide

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Pn룰을 적극적으로 활용해주세요.
    - _P1: 꼭 반영해주세요 (Request changes)_
        - 보안 취약점, 심각한 버그, 중대한 로직 오류
    - _P2: 적극적으로 고려해주세요 (Request changes)_
        - 성능 이슈, 확장성 문제, 잠재적 버그 가능성
    - _P3: 웬만하면 반영해 주세요 (Comment)_
        - 코드 구조 개선, 테스트 케이스 추가, 예외 처리 보완
    - _P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)_
        - 변수명 개선 제안, 메서드 분리 제안
    - _P5: 사소한 의견입니다 (Approve)_
        - 오타 수정, 들여쓰기/공백 조정, 간단한 코드 스타일 수정
    - _ask: 질문이 있습니다 (Comment)_
        - 코드 이해가 안되는 부분, 구현 의도 파악이 어려운 부분

🤖 Generated with [Claude Code](https://claude.ai/code)