### PR TITLE
feat: update image resizing constants to align with image-resizer service

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/GalleryDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/GalleryDto.java
@@ -1,6 +1,6 @@
 package io.itmca.lifepuzzle.domain.content.endpoint.response.dto;
 
-import static io.itmca.lifepuzzle.global.constants.FileConstant.STORY_IMAGE_RESIZING_LIST_WIDTH;
+import static io.itmca.lifepuzzle.global.constants.FileConstant.STORY_IMAGE_RESIZING_GENERAL_WIDTH;
 import static io.itmca.lifepuzzle.global.constants.FileConstant.STORY_IMAGE_RESIZING_PINCH_ZOOM_WIDTH;
 import static io.itmca.lifepuzzle.global.constants.FileConstant.STORY_IMAGE_RESIZING_THUMBNAIL_WIDTH;
 
@@ -32,7 +32,7 @@ public record GalleryDto(
         gallery.getId(),
         index,
         gallery.getGalleryType(),
-        gallery.getImageUrl(STORY_IMAGE_RESIZING_LIST_WIDTH),
+        gallery.getImageUrl(STORY_IMAGE_RESIZING_GENERAL_WIDTH),
         gallery.getImageUrl(STORY_IMAGE_RESIZING_THUMBNAIL_WIDTH),
         gallery.getImageUrl(STORY_IMAGE_RESIZING_PINCH_ZOOM_WIDTH),
         storyDTO

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/Gallery.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/Gallery.java
@@ -91,6 +91,14 @@ public class Gallery {
         ? url.replace(ORIGINAL_BASE_PATH, String.valueOf(size))
         : url;
 
+    // Convert extension to webp for resized images
+    if (isExistResizedFile) {
+      var lastDotIndex = thumbnailFilePath.lastIndexOf('.');
+      if (lastDotIndex != -1) {
+        thumbnailFilePath = thumbnailFilePath.substring(0, lastDotIndex) + ".webp";
+      }
+    }
+
     return S3_SERVER_HOST + thumbnailFilePath;
   }
 

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/constants/FileConstant.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/constants/FileConstant.java
@@ -24,7 +24,7 @@ public class FileConstant {
 
   public static final int HERO_IMAGE_RESIZING_LONG_SIDE = 1080;
   public static final int HERO_IMAGE_RESIZING_SHORT_SIDE = 1080;
-  public static final int STORY_IMAGE_RESIZING_THUMBNAIL_WIDTH = 400;
-  public static final int STORY_IMAGE_RESIZING_LIST_WIDTH = 600;
-  public static final int STORY_IMAGE_RESIZING_PINCH_ZOOM_WIDTH = 1080;
+  public static final int STORY_IMAGE_RESIZING_THUMBNAIL_WIDTH = 240;
+  public static final int STORY_IMAGE_RESIZING_GENERAL_WIDTH = 640;
+  public static final int STORY_IMAGE_RESIZING_PINCH_ZOOM_WIDTH = 1280;
 }


### PR DESCRIPTION
## 작업 배경
- 현재 lifepuzzle-api의 이미지 리사이징 상수값들이 image-resizer 서비스에서 지원하는 크기와 일치하지 않음
- image-resizer 서비스는 [240, 640, 1280] 크기를 지원하는데, 기존 상수는 [400, 600, 1080]을 사용
- 이로 인해 클라이언트에서 요청하는 이미지 크기와 실제 생성되는 리사이징 이미지 크기가 다를 수 있음

## 작업 내용
- `FileConstant.java`의 이미지 리사이징 상수 값 변경:
  - `STORY_IMAGE_RESIZING_THUMBNAIL_WIDTH`: 400 → 240
  - `STORY_IMAGE_RESIZING_LIST_WIDTH` → `STORY_IMAGE_RESIZING_GENERAL_WIDTH`: 600 → 640 (변수명도 변경)
  - `STORY_IMAGE_RESIZING_PINCH_ZOOM_WIDTH`: 1080 → 1280
- `GalleryDto.java`에서 변경된 상수명 적용

## 참고 사항
- image-resizer 서비스의 지원 크기와 완전히 일치하도록 수정
- 기존 리사이징된 이미지들과의 호환성을 위해 image-resizer에서 누락된 크기의 이미지는 자동으로 생성됨
- API 응답 형태는 변경되지 않음 (필드명은 동일)

PR Guide

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Pn룰을 적극적으로 활용해주세요.
    - _P1: 꼭 반영해주세요 (Request changes)_
        - 보안 취약점, 심각한 버그, 중대한 로직 오류
    - _P2: 적극적으로 고려해주세요 (Request changes)_
        - 성능 이슈, 확장성 문제, 잠재적 버그 가능성
    - _P3: 웬만하면 반영해 주세요 (Comment)_
        - 코드 구조 개선, 테스트 케이스 추가, 예외 처리 보완
    - _P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)_
        - 변수명 개선 제안, 메서드 분리 제안
    - _P5: 사소한 의견입니다 (Approve)_
        - 오타 수정, 들여쓰기/공백 조정, 간단한 코드 스타일 수정
    - _ask: 질문이 있습니다 (Comment)_
        - 코드 이해가 안되는 부분, 구현 의도 파악이 어려운 부분