### PR TITLE
feat: JWT 인증 필터에서 /auth/ 경로 제외 처리 추가

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -19,6 +19,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    // 인증 API는 JWT 검증을 건너뜀
+    // FE 오류로 잘못된 token으로 로그인 시도시에도 다른 정보가 정확하다면 성공하도록
+    return request.getRequestURI().startsWith("/auth/");
+  }
+
+  @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                   FilterChain filterChain) throws ServletException, IOException {
     try {


### PR DESCRIPTION
## 작업 배경
- FE에서 잘못된 JWT 토큰으로 인증 API 호출 시에도 다른 정보가 정확하다면 로그인이 성공하도록 개선 필요
- 현재 JWT 인증 필터가 모든 요청에 대해 JWT 검증을 수행하여 인증 API 호출 시에도 토큰 검증이 발생

## 작업 내용
- JwtAuthenticationFilter에 shouldNotFilter 메서드 추가
- /auth/ 경로로 시작하는 요청은 JWT 검증을 건너뛰도록 구현
- 인증 API 호출 시 JWT 토큰 유효성과 관계없이 다른 인증 정보로 로그인 처리 가능

## 참고 사항
- OncePerRequestFilter의 shouldNotFilter 메서드를 오버라이드하여 구현
- 기존 JWT 검증 로직은 그대로 유지하되, 인증 관련 API만 예외 처리