### PR TITLE
[LP-466] feat: Add gallery status to database

### DIFF
--- a/services/lifepuzzle-api/src/main/resources/db/migration/V8_story_photo_add_column_status_size.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V8_story_photo_add_column_status_size.sql
@@ -1,3 +1,2 @@
 ALTER TABLE `story_photo`
-ADD COLUMN status ENUM('pending', 'uploaded', 'failed') NOT NULL DEFAULT 'pending' COMMENT '사진 업로드 상태',
-ADD COLUMN size INT NULL COMMENT '사진 크기';
+ADD COLUMN status VARCHAR(40) NOT NULL DEFAULT 'PENDING' COMMENT '사진 업로드 상태';


### PR DESCRIPTION
## 작업 배경
- LP-466 Presigned URL API 기능 구현을 위한 데이터베이스 스키마 변경
- 갤러리 업로드 상태 추적 기능을 위한 컬럼 추가 필요

## 작업 내용
- `story_photo` 테이블에 `status` 컬럼 추가
  - VARCHAR(40) 타입
  - 기본값: 'PENDING'
  - 업로드 진행 상황 추적 용도

## 참고 사항
- 기존 데이터에는 영향 없음 (기본값 적용)
- 후속 작업에서 Java 엔티티 및 API 로직 구현 예정
- ENUM 대신 VARCHAR 사용으로 유연한 상태 관리 가능

PR Guide

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Pn룰을 적극적으로 활용해주세요.
    - _P1: 꼭 반영해주세요 (Request changes)_
        - 보안 취약점, 심각한 버그, 중대한 로직 오류
    - _P2: 적극적으로 고려해주세요 (Request changes)_
        - 성능 이슈, 확장성 문제, 잠재적 버그 가능성
    - _P3: 웬만하면 반영해 주세요 (Comment)_
        - 코드 구조 개선, 테스트 케이스 추가, 예외 처리 보완
    - _P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)_
        - 변수명 개선 제안, 메서드 분리 제안
    - _P5: 사소한 의견입니다 (Approve)_
        - 오타 수정, 들여쓰기/공백 조정, 간단한 코드 스타일 수정
    - _ask: 질문이 있습니다 (Comment)_
        - 코드 이해가 안되는 부분, 구현 의도 파악이 어려운 부분