### PR TITLE
[SHOW][LP-491] feat: AI 드라이빙 비디오 API 구현

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git push:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiDrivingVideoEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiDrivingVideoEndpoint.java
@@ -1,0 +1,29 @@
+package io.itmca.lifepuzzle.domain.ai.endpoint;
+
+import io.itmca.lifepuzzle.domain.ai.endpoint.response.AiDrivingVideoResponse;
+import io.itmca.lifepuzzle.domain.ai.endpoint.response.dto.AiDrivingVideoDto;
+import io.itmca.lifepuzzle.domain.ai.service.AiDrivingVideoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "AI 드라이빙 비디오")
+public class AiDrivingVideoEndpoint {
+  
+  private final AiDrivingVideoService aiDrivingVideoService;
+  
+  @Operation(summary = "드라이빙 비디오 목록 조회")
+  @GetMapping("/v1/ai/driving-videos")
+  public ResponseEntity<AiDrivingVideoResponse> getDrivingVideos() {
+    var drivingVideos = aiDrivingVideoService.getAllActiveDrivingVideos();
+    var drivingVideoDtos = AiDrivingVideoDto.listFrom(drivingVideos);
+    var response = AiDrivingVideoResponse.from(drivingVideoDtos);
+    
+    return ResponseEntity.ok(response);
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/AiDrivingVideoResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/AiDrivingVideoResponse.java
@@ -2,13 +2,10 @@ package io.itmca.lifepuzzle.domain.ai.endpoint.response;
 
 import io.itmca.lifepuzzle.domain.ai.endpoint.response.dto.AiDrivingVideoDto;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class AiDrivingVideoResponse {
-  private final List<AiDrivingVideoDto> drivingVideos;
+public record AiDrivingVideoResponse(
+    List<AiDrivingVideoDto> drivingVideos
+) {
   
   public static AiDrivingVideoResponse from(List<AiDrivingVideoDto> drivingVideos) {
     return new AiDrivingVideoResponse(drivingVideos);

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/AiDrivingVideoResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/AiDrivingVideoResponse.java
@@ -1,0 +1,16 @@
+package io.itmca.lifepuzzle.domain.ai.endpoint.response;
+
+import io.itmca.lifepuzzle.domain.ai.endpoint.response.dto.AiDrivingVideoDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AiDrivingVideoResponse {
+  private final List<AiDrivingVideoDto> drivingVideos;
+  
+  public static AiDrivingVideoResponse from(List<AiDrivingVideoDto> drivingVideos) {
+    return new AiDrivingVideoResponse(drivingVideos);
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/dto/AiDrivingVideoDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/dto/AiDrivingVideoDto.java
@@ -1,0 +1,32 @@
+package io.itmca.lifepuzzle.domain.ai.endpoint.response.dto;
+
+import io.itmca.lifepuzzle.domain.ai.entity.AiDrivingVideo;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AiDrivingVideoDto {
+  private final Long id;
+  private final String name;
+  private final String url;
+  private final String thumbnailUrl;
+  private final String description;
+  
+  public static AiDrivingVideoDto from(AiDrivingVideo aiDrivingVideo) {
+    return new AiDrivingVideoDto(
+        aiDrivingVideo.getId(),
+        aiDrivingVideo.getName(),
+        aiDrivingVideo.getUrl(),
+        aiDrivingVideo.getThumbnailUrl(),
+        aiDrivingVideo.getDescription()
+    );
+  }
+  
+  public static List<AiDrivingVideoDto> listFrom(List<AiDrivingVideo> aiDrivingVideos) {
+    return aiDrivingVideos.stream()
+        .map(AiDrivingVideoDto::from)
+        .toList();
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/dto/AiDrivingVideoDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/dto/AiDrivingVideoDto.java
@@ -2,17 +2,14 @@ package io.itmca.lifepuzzle.domain.ai.endpoint.response.dto;
 
 import io.itmca.lifepuzzle.domain.ai.entity.AiDrivingVideo;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class AiDrivingVideoDto {
-  private final Long id;
-  private final String name;
-  private final String url;
-  private final String thumbnailUrl;
-  private final String description;
+public record AiDrivingVideoDto(
+    Long id,
+    String name,
+    String url,
+    String thumbnailUrl,
+    String description
+) {
   
   public static AiDrivingVideoDto from(AiDrivingVideo aiDrivingVideo) {
     return new AiDrivingVideoDto(

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/entity/AiDrivingVideo.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/entity/AiDrivingVideo.java
@@ -1,0 +1,63 @@
+package io.itmca.lifepuzzle.domain.ai.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Table(name = "ai_driving_video")
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AiDrivingVideo {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  
+  @Column(nullable = false, length = 100)
+  private String name;
+  
+  @Column(nullable = false, length = 500)
+  private String url;
+  
+  @Column(length = 500)
+  private String thumbnailUrl;
+  
+  @Column(columnDefinition = "TEXT")
+  private String description;
+  
+  @Column(nullable = false)
+  @Builder.Default
+  private Integer priority = 0;
+  
+  @Column
+  private LocalDateTime deletedAt;
+  
+  @Column(nullable = false, updatable = false)
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+  
+  @Column(nullable = false)
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+  
+  public boolean isDeleted() {
+    return deletedAt != null;
+  }
+  
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiDrivingVideoRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiDrivingVideoRepository.java
@@ -1,0 +1,12 @@
+package io.itmca.lifepuzzle.domain.ai.repository;
+
+import io.itmca.lifepuzzle.domain.ai.entity.AiDrivingVideo;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AiDrivingVideoRepository extends JpaRepository<AiDrivingVideo, Long> {
+  
+  @Query("SELECT a FROM AiDrivingVideo a WHERE a.deletedAt IS NULL ORDER BY a.priority DESC, a.createdAt DESC")
+  List<AiDrivingVideo> findAllActiveOrderByCreatedAtDesc();
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiDrivingVideoService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiDrivingVideoService.java
@@ -1,0 +1,20 @@
+package io.itmca.lifepuzzle.domain.ai.service;
+
+import io.itmca.lifepuzzle.domain.ai.entity.AiDrivingVideo;
+import io.itmca.lifepuzzle.domain.ai.repository.AiDrivingVideoRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AiDrivingVideoService {
+  
+  private final AiDrivingVideoRepository aiDrivingVideoRepository;
+  
+  public List<AiDrivingVideo> getAllActiveDrivingVideos() {
+    return aiDrivingVideoRepository.findAllActiveOrderByCreatedAtDesc();
+  }
+}

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V9__create_ai_driving_video_table.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V9__create_ai_driving_video_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `ai_driving_video` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '드라이빙 비디오 ID',
+  `name` VARCHAR(100) NOT NULL COMMENT '드라이빙 비디오 이름',
+  `url` VARCHAR(500) NOT NULL COMMENT '드라이빙 비디오 URL',
+  `thumbnail_url` VARCHAR(500) COMMENT '썸네일 이미지 URL',
+  `description` TEXT COMMENT '드라이빙 비디오 설명',
+  `priority` INT NOT NULL DEFAULT 0 COMMENT '우선순위 (높을수록 우선)',
+  `deleted_at` TIMESTAMP NULL COMMENT '삭제일시',
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시'
+) COMMENT 'AI 드라이빙 비디오 테이블';
+
+CREATE INDEX `idx_ai_driving_video_priority_created` ON `ai_driving_video` (`deleted_at`, `priority` DESC, `created_at` DESC);


### PR DESCRIPTION
## 작업 배경
- 이미지를 드라이빙 비디오를 사용해서 움직이는 동영상을 만드는 기능 개발 필요
- 드라이빙 비디오 URL 목록을 DB에 저장해두고 클라이언트에 제공하는 API 구현

## 작업 내용
- `ai_driving_video` 테이블 생성 (Flyway V9 마이그레이션)
  - id, name, url, thumbnail_url, description, priority, deleted_at, created_at, updated_at 컬럼
  - 우선순위 기반 정렬을 위한 priority 컬럼 추가 (기본값 0)
  - 소프트 삭제를 위한 deleted_at 컬럼
  - 성능 최적화를 위한 인덱스 생성 (deleted_at, priority DESC, created_at DESC)
- `AiDrivingVideo` JPA 엔티티 구현
  - 소프트 삭제 기능 (isDeleted(), delete() 메서드)
- `AiDrivingVideoRepository` 구현
  - 활성 상태인 드라이빙 비디오만 우선순위/생성일시 순으로 조회하는 쿼리
- `AiDrivingVideoService` 비즈니스 로직 구현
- `AiDrivingVideoEndpoint` REST API 구현
  - `GET /v1/ai/driving-videos` 엔드포인트
  - Swagger 문서화 포함
- DTO 구현 (`AiDrivingVideoDto`, `AiDrivingVideoResponse`)

## 참고 사항
- API 응답 형태:
```json
{
  "drivingVideos": [
    {
      "id": 1,
      "name": "드라이빙 비디오 1", 
      "url": "https://example.com/video1.mp4",
      "thumbnailUrl": "https://example.com/thumb1.jpg",
      "description": "설명"
    }
  ]
}
```
- 우선순위 값이 높을수록 상위에 노출됨
- 소프트 삭제 방식으로 데이터 무결성 보장
- 기존 코드 패턴과 일치하는 구조로 구현

PR Guide

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Pn룰을 적극적으로 활용해주세요.
    - _P1: 꼭 반영해주세요 (Request changes)_
        - 보안 취약점, 심각한 버그, 중대한 로직 오류
    - _P2: 적극적으로 고려해주세요 (Request changes)_
        - 성능 이슈, 확장성 문제, 잠재적 버그 가능성
    - _P3: 웬만하면 반영해 주세요 (Comment)_
        - 코드 구조 개선, 테스트 케이스 추가, 예외 처리 보완
    - _P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)_
        - 변수명 개선 제안, 메서드 분리 제안
    - _P5: 사소한 의견입니다 (Approve)_
        - 오타 수정, 들여쓰기/공백 조정, 간단한 코드 스타일 수정
    - _ask: 질문이 있습니다 (Comment)_
        - 코드 이해가 안되는 부분, 구현 의도 파악이 어려운 부분