### PR TITLE
feat: 갤러리 업로드 완료 API 구현

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/GalleryUploadEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/GalleryUploadEndpoint.java
@@ -1,9 +1,14 @@
 package io.itmca.lifepuzzle.domain.content.endpoint;
 
+import io.itmca.lifepuzzle.domain.content.endpoint.request.GalleryUploadCompleteRequest;
 import io.itmca.lifepuzzle.domain.content.endpoint.request.PresignedUrlRequest;
+import io.itmca.lifepuzzle.domain.content.endpoint.response.GalleryUploadCompleteResponse;
 import io.itmca.lifepuzzle.domain.content.endpoint.response.PresignedUrlResponse;
+import io.itmca.lifepuzzle.domain.content.service.GalleryWriteService;
 import io.itmca.lifepuzzle.domain.content.service.PresignedUrlService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,14 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Presigned URL")
+@Tag(name = "Gallery Upload")
 public class GalleryUploadEndpoint {
   private final PresignedUrlService presignedUrlService;
+  private final GalleryWriteService galleryWriteService;
 
   @PostMapping("/v1/galleries/presigned-urls")
-  public PresignedUrlResponse generatePresignedUrl(@RequestBody PresignedUrlRequest presignedUrlRequest) {
-    var presignedUrlResponse = presignedUrlService.createPresignedUrls(presignedUrlRequest);
+  @Operation(summary = "Presigned URL 생성", description = "S3 파일 업로드를 위한 presigned URL을 생성합니다")
+  public PresignedUrlResponse generatePresignedUrl(@Valid @RequestBody PresignedUrlRequest presignedUrlRequest) {
+    return presignedUrlService.createPresignedUrls(presignedUrlRequest);
+  }
 
-    return presignedUrlResponse;
+  @PostMapping("/v1/galleries/upload-complete")
+  @Operation(summary = "업로드 완료 처리", description = "S3 업로드 완료 후 갤러리 상태를 업데이트합니다")
+  public GalleryUploadCompleteResponse completeUpload(@Valid @RequestBody GalleryUploadCompleteRequest request) {
+    return galleryWriteService.completeUploads(request.fileKeys());
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/request/GalleryUploadCompleteRequest.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/request/GalleryUploadCompleteRequest.java
@@ -1,0 +1,12 @@
+package io.itmca.lifepuzzle.domain.content.endpoint.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record GalleryUploadCompleteRequest(
+    @NotEmpty
+    @Size(max = 30, message = "파일 키는 최대 30개까지 가능합니다")
+    List<String> fileKeys
+) {
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/GalleryUploadCompleteResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/GalleryUploadCompleteResponse.java
@@ -1,0 +1,11 @@
+package io.itmca.lifepuzzle.domain.content.endpoint.response;
+
+import io.itmca.lifepuzzle.domain.content.endpoint.response.dto.GalleryUploadResultDto;
+import java.util.List;
+
+public record GalleryUploadCompleteResponse(
+    List<GalleryUploadResultDto> results,
+    int successCount,
+    int failureCount
+) {
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/GalleryUploadResultDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/GalleryUploadResultDto.java
@@ -1,0 +1,11 @@
+package io.itmca.lifepuzzle.domain.content.endpoint.response.dto;
+
+import io.itmca.lifepuzzle.domain.content.type.GalleryStatus;
+
+public record GalleryUploadResultDto(
+    String fileKey,
+    Long galleryId,
+    GalleryStatus status,
+    String message
+) {
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/Gallery.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/Gallery.java
@@ -58,6 +58,7 @@ public class Gallery {
   @Convert(converter = JsonListConverter.class)
   @Builder.Default
   private List<Integer> resizedSizes = new ArrayList<>();
+  @Setter
   @Column(name = "status", nullable = false)
   @Enumerated(EnumType.STRING)
   private GalleryStatus galleryStatus;

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/GalleryRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/GalleryRepository.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
   Optional<List<Gallery>> findByHeroId(Long heroId);
+  
+  Optional<Gallery> findByUrl(String url);
 
   @Query("SELECT g FROM Gallery g "
          + "LEFT JOIN FETCH g.storyMaps sm "

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/GalleryWriteService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/GalleryWriteService.java
@@ -3,10 +3,13 @@ package io.itmca.lifepuzzle.domain.content.service;
 import static io.itmca.lifepuzzle.domain.content.type.GalleryType.IMAGE;
 import static io.itmca.lifepuzzle.domain.content.type.GalleryType.VIDEO;
 
+import io.itmca.lifepuzzle.domain.content.endpoint.response.GalleryUploadCompleteResponse;
+import io.itmca.lifepuzzle.domain.content.endpoint.response.dto.GalleryUploadResultDto;
 import io.itmca.lifepuzzle.domain.content.entity.Gallery;
 import io.itmca.lifepuzzle.domain.content.event.PhotoUploadEventPublisher;
 import io.itmca.lifepuzzle.domain.content.repository.GalleryRepository;
 import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
+import io.itmca.lifepuzzle.domain.content.type.GalleryStatus;
 import io.itmca.lifepuzzle.global.exception.GalleryItemNotFoundException;
 import io.itmca.lifepuzzle.global.file.domain.StoryImageFile;
 import io.itmca.lifepuzzle.global.file.domain.StoryVideoFile;
@@ -67,6 +70,65 @@ public class GalleryWriteService {
               gallery.getUrl()
           );
         });
+  }
+
+  @Transactional
+  public GalleryUploadCompleteResponse completeUploads(List<String> fileKeys) {
+    List<GalleryUploadResultDto> results = new ArrayList<>();
+    int successCount = 0;
+    int failureCount = 0;
+
+    for (String fileKey : fileKeys) {
+      Optional<Gallery> galleryOpt = galleryRepository.findByUrl(fileKey);
+      
+      if (galleryOpt.isEmpty()) {
+        results.add(new GalleryUploadResultDto(
+            fileKey, 
+            null, 
+            GalleryStatus.FAILED, 
+            "Gallery not found for file key"
+        ));
+        failureCount++;
+        continue;
+      }
+
+      Gallery gallery = galleryOpt.get();
+      
+      try {
+        gallery.setGalleryStatus(GalleryStatus.UPLOADED);
+        galleryRepository.save(gallery);
+        
+        results.add(new GalleryUploadResultDto(
+            fileKey,
+            gallery.getId(),
+            GalleryStatus.UPLOADED,
+            "Upload completed successfully"
+        ));
+        successCount++;
+        
+        if (gallery.isImage()) {
+          photoUploadEventPublisher.publishPhotoUploadEvent(
+              gallery.getId(),
+              gallery.getHeroId(),
+              gallery.getUrl()
+          );
+        }
+        
+      } catch (Exception e) {
+        gallery.setGalleryStatus(GalleryStatus.FAILED);
+        galleryRepository.save(gallery);
+        
+        results.add(new GalleryUploadResultDto(
+            fileKey,
+            gallery.getId(),
+            GalleryStatus.FAILED,
+            "Failed to update status: " + e.getMessage()
+        ));
+        failureCount++;
+      }
+    }
+
+    return new GalleryUploadCompleteResponse(results, successCount, failureCount);
   }
 
   public Optional<List<?>> test() {


### PR DESCRIPTION
## Summary
- FE에서 S3 업로드 완료 후 Gallery 상태를 업데이트하는 API 구현
- 업로드 완료 요청/응답 DTO 추가
- Gallery 엔티티 상태 업데이트 로직 구현
- 이미지 업로드 완료 시 리사이징 이벤트 자동 발행

## Key Changes
- **API**: `POST /v1/galleries/upload-complete` 엔드포인트 추가
- **DTO**: `GalleryUploadCompleteRequest`, `GalleryUploadCompleteResponse` 추가
- **Entity**: Gallery 엔티티에 galleryStatus setter 추가
- **Repository**: GalleryRepository에 findByUrl 메서드 추가
- **Service**: 파일 키 목록으로 상태 일괄 업데이트 로직 구현

## API Usage
```json
POST /v1/galleries/upload-complete
{
  "fileKeys": ["hero/89/image/740/original/photo.jpg"]
}
```

## Test plan
- [ ] presigned URL 생성 후 S3 업로드 테스트
- [ ] 업로드 완료 API 호출로 상태 업데이트 확인
- [ ] 이미지 리사이징 이벤트 발행 확인
- [ ] 실패 케이스 처리 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)