### PR TITLE
chore: rename story_gallery_map table to story_gallery

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/StoryGallery.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/StoryGallery.java
@@ -17,14 +17,14 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
-@Table(name = "gallery_story_map")
+@Table(name = "story_gallery")
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
-@IdClass(StoryGalleryMapId.class)
+@IdClass(StoryGalleryId.class)
 public class StoryGallery {
   @Id
   @Column(name = "story_id", nullable = false)

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/StoryGalleryId.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/entity/StoryGalleryId.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @EqualsAndHashCode
 @Builder
-public class StoryGalleryMapId implements Serializable {
+public class StoryGalleryId implements Serializable {
   private String storyId;
   private Long galleryId;
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/StoryGalleryRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/StoryGalleryRepository.java
@@ -1,10 +1,10 @@
 package io.itmca.lifepuzzle.domain.content.repository;
 
 import io.itmca.lifepuzzle.domain.content.entity.StoryGallery;
-import io.itmca.lifepuzzle.domain.content.entity.StoryGalleryMapId;
+import io.itmca.lifepuzzle.domain.content.entity.StoryGalleryId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StoryGalleryRepository extends JpaRepository<StoryGallery, StoryGalleryMapId> {
+public interface StoryGalleryRepository extends JpaRepository<StoryGallery, StoryGalleryId> {
 }

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V20__rename_story_gallery_map_to_story_gallery.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V20__rename_story_gallery_map_to_story_gallery.sql
@@ -1,5 +1,21 @@
--- Rename story_gallery_map table to story_gallery for better naming convention
+-- Rename gallery_story_map table to story_gallery for better naming convention
 -- The table represents the relationship between Story and Gallery entities
--- Removing "_map" suffix makes the name more concise and intuitive
+-- This standardizes the naming to follow entity_relationship pattern
 
-RENAME TABLE `story_gallery_map` TO `story_gallery`;
+-- Check if gallery_story_map exists and rename it
+SET @sql = (SELECT IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'gallery_story_map') > 0,
+  'RENAME TABLE `gallery_story_map` TO `story_gallery`',
+  'SELECT "gallery_story_map table does not exist - skipping rename"'
+));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Also check if story_gallery_map exists and rename it (fallback)
+SET @sql = (SELECT IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'story_gallery_map') > 0,
+  'RENAME TABLE `story_gallery_map` TO `story_gallery`',
+  'SELECT "story_gallery_map table does not exist - skipping rename"'
+));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V20__rename_story_gallery_map_to_story_gallery.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V20__rename_story_gallery_map_to_story_gallery.sql
@@ -1,0 +1,5 @@
+-- Rename story_gallery_map table to story_gallery for better naming convention
+-- The table represents the relationship between Story and Gallery entities
+-- Removing "_map" suffix makes the name more concise and intuitive
+
+RENAME TABLE `story_gallery_map` TO `story_gallery`;


### PR DESCRIPTION
## 작업 배경
- `story_gallery_map` 테이블명이 불필요하게 길고 `_map` 접미사가 중복적임
- 테이블 자체가 이미 Story와 Gallery 간의 매핑을 나타내므로 더 간결한 이름이 적절함
- 일관된 네이밍 규칙을 위해 `entity1_entity2` 패턴으로 통일

## 작업 내용
- 테이블명을 `gallery_story_map`/`story_gallery_map`에서 `story_gallery`로 변경
- JPA 엔티티 클래스 `StoryGalleryMapId`를 `StoryGalleryId`로 리네임
- `StoryGallery` 엔티티의 `@Table` 어노테이션 업데이트
- `StoryGalleryRepository`에서 `StoryGalleryId` 사용하도록 수정
- V20 마이그레이션 파일 추가 (다양한 환경의 테이블명 고려)

## 참고 사항
- 마이그레이션은 기존 `gallery_story_map`과 `story_gallery_map` 두 케이스 모두 처리
- 테이블이 존재하지 않는 경우 에러 없이 건너뛰도록 안전 장치 적용
- 컴파일 및 테스트 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/code)