### PR TITLE
fix: HikariCP 연결 풀 설정 최적화

### DIFF
--- a/services/lifepuzzle-api/src/main/resources/application-prod.yml
+++ b/services/lifepuzzle-api/src/main/resources/application-prod.yml
@@ -3,3 +3,6 @@ spring:
     url: ${DB_PROD_URL}
     username: ${DB_PROD_USERNAME}
     password: ${DB_PROD_PASSWORD}
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 15

--- a/services/lifepuzzle-api/src/main/resources/application.yml
+++ b/services/lifepuzzle-api/src/main/resources/application.yml
@@ -4,12 +4,12 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
-      maximum-pool-size: 20
-      minimum-idle: 10
-      idle-timeout: 300000
-      max-lifetime: 1800000
-      connection-timeout: 20000
-      leak-detection-threshold: 60000
+      maximum-pool-size: 5
+      minimum-idle: 2
+      idle-timeout: 300000 # 5 minutes
+      max-lifetime: 1800000 # 30 minutes
+      connection-timeout: 20000 # 20 seconds
+      leak-detection-threshold: 60000 # 60 seconds
       connection-test-query: SELECT 1
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect

--- a/services/lifepuzzle-api/src/main/resources/application.yml
+++ b/services/lifepuzzle-api/src/main/resources/application.yml
@@ -3,6 +3,14 @@ spring:
     active: prod
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 10
+      idle-timeout: 300000
+      max-lifetime: 1800000
+      connection-timeout: 20000
+      leak-detection-threshold: 60000
+      connection-test-query: SELECT 1
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
   #    hibernate:


### PR DESCRIPTION
## 작업 배경
- HikariPool-1 - Failed to validate connection (No operations allowed after connection closed.) 에러 발생
- MySQL 연결 timeout과 HikariCP 기본 설정 간의 불일치로 인한 연결 검증 실패
- 환경별 리소스 사용량 최적화 필요

## 작업 내용
- **연결 유효성 검사**: connection-test-query: SELECT 1 추가로 끊어진 연결 사전 감지
- **연결 수명 관리**: max-lifetime: 30분으로 설정하여 MySQL wait_timeout 문제 방지
- **연결 누수 감지**: leak-detection-threshold: 60초로 코드 버그 조기 발견  
- **환경별 풀 크기 최적화**:
  - 로컬 환경: maximum-pool-size: 5, minimum-idle: 2 (리소스 절약)
  - 운영 환경: maximum-pool-size: 30, minimum-idle: 15 (높은 트래픽 대응)
- **가독성 개선**: 시간 관련 설정에 주석 추가 (5 minutes, 30 minutes 등)

## 참고 사항
- 기본 설정을 로컬 환경에 맞추고, 운영 환경은 application-prod.yml에서 오버라이드하는 구조로 변경
- HikariCP 기본 max-lifetime(30분)을 명시적으로 설정하여 MySQL의 기본 wait_timeout(8시간)보다 짧게 유지
- 운영 배포 후 연결 에러 모니터링 및 연결 풀 메트릭 확인 필요