### PR TITLE
feat: Spring Boot Actuator 설정 추가

### DIFF
--- a/services/lifepuzzle-api/build.gradle
+++ b/services/lifepuzzle-api/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     //	Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/services/lifepuzzle-api/src/main/resources/application-prod.yml
+++ b/services/lifepuzzle-api/src/main/resources/application-prod.yml
@@ -6,3 +6,15 @@ spring:
     hikari:
       maximum-pool-size: 30
       minimum-idle: 15
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: never
+  info:
+    env:
+      enabled: false

--- a/services/lifepuzzle-api/src/main/resources/application-test.yml
+++ b/services/lifepuzzle-api/src/main/resources/application-test.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     # URL, username, password are set dynamically by @DynamicPropertySource
@@ -77,6 +79,15 @@ apple:
     -----BEGIN PRIVATE KEY-----
     TEST_PRIVATE_KEY_FOR_TESTING_ONLY
     -----END PRIVATE KEY-----
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
 
 logging:
   level:

--- a/services/lifepuzzle-api/src/main/resources/application.yml
+++ b/services/lifepuzzle-api/src/main/resources/application.yml
@@ -90,6 +90,19 @@ springdoc:
     - group: 갤러리
       paths-to-match:   /**/galleries/**
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: when-authorized
+  info:
+    env:
+      enabled: true
+
 sentry:
   dsn: ${SENTRY_DSN:}
   enable-tracing: true


### PR DESCRIPTION
## 작업 배경
- 애플리케이션 모니터링 및 헬스체크 기능 필요
- HikariCP 연결 풀 상태 등 시스템 메트릭 모니터링 요구
- 운영 환경에서 안전한 모니터링 엔드포인트 노출 필요

## 작업 내용
- **의존성 추가**: spring-boot-starter-actuator를 Monitoring 섹션으로 정리
- **환경별 Actuator 설정**:
  - 로컬/개발: health, info, metrics 엔드포인트 노출, 환경 변수 정보 표시
  - 운영: health, info만 노출, 상세 정보 및 환경 변수 숨김 (보안 강화)
  - 테스트: health 엔드포인트만, Bean 정의 오버라이드 허용 설정 추가
- **보안 설정**: 운영 환경에서 민감한 정보 노출 방지
- **접근 경로**: /actuator/* 로 통일

## 참고 사항
- 사용 가능한 엔드포인트:
  - GET /actuator/health - 애플리케이션 및 HikariCP 상태 확인
  - GET /actuator/info - 애플리케이션 정보 (환경별 설정)
  - GET /actuator/metrics - 성능 메트릭 (로컬만)
- 테스트 환경에서 BeanDefinitionOverrideException 해결을 위한 설정 추가