### PR TITLE
feat: presigned URL 응답에 FE용 headers 정보 추가

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/PresignedUrlResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/PresignedUrlResponse.java
@@ -1,7 +1,11 @@
 package io.itmca.lifepuzzle.domain.content.endpoint.response;
 
-import io.itmca.lifepuzzle.domain.content.endpoint.response.dto.PresignedUrlDto;
 import java.util.List;
 
 public record PresignedUrlResponse(List<PresignedUrlDto> presignedUrls) {
+
+  public record PresignedUrlDto(String fileKey, String url, Headers headers) {
+
+    public record Headers(String host, String contentType, String cacheControl) {}
+  }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/PresignedUrlDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/PresignedUrlDto.java
@@ -1,3 +1,6 @@
 package io.itmca.lifepuzzle.domain.content.endpoint.response.dto;
 
-public record PresignedUrlDto(String fileKey, String url) {}
+public record PresignedUrlDto(String fileKey, String url, Headers headers) {
+
+  public record Headers(String contentType, String cacheControl) {}
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/PresignedUrlDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/PresignedUrlDto.java
@@ -1,6 +1,0 @@
-package io.itmca.lifepuzzle.domain.content.endpoint.response.dto;
-
-public record PresignedUrlDto(String fileKey, String url, Headers headers) {
-
-  public record Headers(String contentType, String cacheControl) {}
-}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/PresignedUrlService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/PresignedUrlService.java
@@ -50,7 +50,8 @@ public class PresignedUrlService {
 
       gallery.setUrl(key);
 
-      urls.add(new PresignedUrlDto(key, presignedUrl));
+      var headers = new PresignedUrlDto.Headers(file.contentType(), "public, max-age=31536000, immutable");
+      urls.add(new PresignedUrlDto(key, presignedUrl, headers));
     }
 
     return new PresignedUrlResponse(urls);

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/PresignedUrlService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/PresignedUrlService.java
@@ -4,7 +4,7 @@ import static io.itmca.lifepuzzle.global.constants.FileConstant.NEW_STORY_IMAGE_
 
 import io.itmca.lifepuzzle.domain.content.endpoint.request.PresignedUrlRequest;
 import io.itmca.lifepuzzle.domain.content.endpoint.response.PresignedUrlResponse;
-import io.itmca.lifepuzzle.domain.content.endpoint.response.dto.PresignedUrlDto;
+import io.itmca.lifepuzzle.domain.content.endpoint.response.PresignedUrlResponse.PresignedUrlDto;
 import io.itmca.lifepuzzle.domain.content.entity.Gallery;
 import io.itmca.lifepuzzle.domain.content.repository.GalleryRepository;
 import io.itmca.lifepuzzle.domain.content.type.GalleryStatus;
@@ -50,7 +50,8 @@ public class PresignedUrlService {
 
       gallery.setUrl(key);
 
-      var headers = new PresignedUrlDto.Headers(file.contentType(), "public, max-age=31536000, immutable");
+      String host = String.format("%s.s3.ap-northeast-2.amazonaws.com", bucket);
+      var headers = new PresignedUrlDto.Headers(host, file.contentType(), "public, max-age=31536000, immutable");
       urls.add(new PresignedUrlDto(key, presignedUrl, headers));
     }
 


### PR DESCRIPTION
## 작업 배경
- FE에서 S3 업로드 시 사용할 헤더 정보가 필요
- Content-Type과 Cache-Control 헤더를 API 응답에 포함해야 함
- 일관된 캐싱 정책 적용을 위한 헤더 정보 제공

## 작업 내용
- **PresignedUrlDto 구조 개선**: nested Headers record 추가
- **헤더 정보 포함**: 
  - `contentType`: 파일의 MIME 타입 (예: "image/webp")
  - `cacheControl`: "public, max-age=31536000, immutable" (1년 캐싱)
- **타입 안전성**: Map 대신 record 사용으로 타입 안전성 확보

## API 응답 변경사항

### Before:
```json
{
  "presignedUrls": [
    {
      "fileKey": "heroes/1/galleries/123/image.webp",
      "url": "https://s3.amazonaws.com/..."
    }
  ]
}
```

### After:
```json
{
  "presignedUrls": [
    {
      "fileKey": "heroes/1/galleries/123/image.webp", 
      "url": "https://s3.amazonaws.com/...",
      "headers": {
        "contentType": "image/webp",
        "cacheControl": "public, max-age=31536000, immutable"
      }
    }
  ]
}
```

## 참고 사항
- FE에서 업로드 시 headers 정보를 사용하여 올바른 Content-Type과 Cache-Control 설정
- 기존 API 구조에 필드 추가만으로 하위 호환성 유지
- nested record 패턴으로 응집도 높은 구조 설계