### PR TITLE
refactor: 파일 경로를 단수에서 복수형으로 변경

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/constants/FileConstant.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/constants/FileConstant.java
@@ -11,12 +11,12 @@ public class FileConstant {
   public static final String ORIGINAL_BASE_PATH = "original";
   public static final String FILE_NAMES_SEPARATOR = "||";
 
-  public static final String HERO_PROFILE_IMAGE_BASE_PATH_FORMAT = "hero/profile/%s/image/";
-  public static final String USER_PROFILE_IMAGE_BASE_PATH_FORMAT = "user/profile/%s/image/";
-  public static final String STORY_IMAGE_BASE_PATH_FORMAT = "hero/%s/image/original/";
-  public static final String NEW_STORY_IMAGE_BASE_PATH_FORMAT = "hero/%s/image/%s/original/";
-  public static final String STORY_VIDEO_BASE_PATH_FORMAT = "hero/%s/video/original/";
-  public static final String STORY_VOICE_BASE_PATH_FORMAT = "stories/%s/voice/original/";
+  public static final String HERO_PROFILE_IMAGE_BASE_PATH_FORMAT = "heroes/profile/%s/images/";
+  public static final String USER_PROFILE_IMAGE_BASE_PATH_FORMAT = "users/profile/%s/images/";
+  public static final String STORY_IMAGE_BASE_PATH_FORMAT = "heroes/%s/images/original/";
+  public static final String NEW_STORY_IMAGE_BASE_PATH_FORMAT = "heroes/%s/images/%s/original/";
+  public static final String STORY_VIDEO_BASE_PATH_FORMAT = "heroes/%s/videos/original/";
+  public static final String STORY_VOICE_BASE_PATH_FORMAT = "stories/%s/voices/original/";
 
   public static final int VIDEO_RESIZING_WIDTH = 854;
   public static final int VIDEO_RESIZING_HEIGHT = 480;


### PR DESCRIPTION
## 작업 배경
- 파일 경로의 일관성을 위해 단수형을 복수형으로 변경 요청
- NEW_STORY_IMAGE_BASE_PATH_FORMAT에 hero, image를 복수형으로 적용
- image-resizer의 파일 조직화 로직도 복수형 경로로 통일

## 작업 내용
- **FileConstant.java 변경사항**:
  - `hero` → `heroes`
  - `image` → `images` 
  - `video` → `videos`
  - `voice` → `voices`
  - `user` → `users`

- **image-resizer/main.go 변경사항**:
  - `organizePhotoStructure()`: 새로운 파일은 복수형 경로로 저장
  - `isAlreadyOrganized()`: 기존 단수형 경로와의 호환성 유지 (legacy pattern 지원)
  - 리사이징된 이미지 생성 경로도 복수형으로 변경

## 참고 사항
- 기존 단수형 경로와의 호환성을 완전히 유지
- 새로운 파일만 복수형 경로로 저장됨
- 기존 파일들은 점진적으로 복수형 경로로 이동 가능

🤖 Generated with [Claude Code](https://claude.ai/code)