### PR TITLE
fix: image-resizer 빌드 오류 수정 - 사용되지 않는 heroId 변수 제거

### DIFF
--- a/services/image-resizer/main.go
+++ b/services/image-resizer/main.go
@@ -541,7 +541,6 @@ func isInSingularOrganizedStructure(url string, photoId int64) bool {
 // migrateSingularToPlural migrates photos from singular path structure to plural path structure
 func migrateSingularToPlural(gallery *database.Gallery, s3Client *storage.S3Client, db *database.Database) error {
 	oldPath := gallery.Url
-	heroId := gallery.HeroID
 
 	// Convert singular path to plural path
 	// hero/{heroId}/image/{photoId}/original/{filename} -> heroes/{heroId}/images/{photoId}/original/{filename}


### PR DESCRIPTION
## 작업 배경
- image-resizer 빌드 시 "declared and not used: heroId" 오류 발생
- Go 컴파일러에서 사용되지 않는 변수에 대한 오류 발생

## 작업 내용
- **migrateSingularToPlural 함수 수정**:
  - 선언되었지만 사용되지 않는 `heroId` 변수 제거
  - 경로 변환 로직은 `convertSingularPathToPlural` 함수가 담당하므로 heroId 불필요

## 참고 사항
- 빌드 오류 해결로 image-resizer 정상 컴파일 가능
- 기능상 변경 없음, 단순 컴파일 오류 수정

🤖 Generated with [Claude Code](https://claude.ai/code)