### PR TITLE
[SHIP] fix: StoryWriteEndpoint에서 Long 타입 비교를 equals로 변경

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/StoryWriteEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/StoryWriteEndpoint.java
@@ -99,12 +99,12 @@ public class StoryWriteEndpoint {
                           @AuthenticationPrincipal AuthPayload authPayload) {
     var story = storyQueryService.findById(storyKey);
 
-    if (story.getUserId() != authPayload.getUserId()) {
+    if (!story.getUserId().equals(authPayload.getUserId())) {
       throw new UserNotAccessibleToStoryException(authPayload.getUserId(), storyKey);
     }
 
     var user = userQueryService.findByUserNo(authPayload.getUserId());
-    if (story.getHeroId() != user.getRecentHeroNo()) {
+    if (!story.getHeroId().equals(user.getRecentHeroNo())) {
       throw new HeroNotAccessibleToStoryException(user.getRecentHeroNo(), storyKey);
     }
 


### PR DESCRIPTION
## 작업 배경
- StoryWriteEndpoint에서 Long 타입을 != 연산자로 비교하는 코드 발견
- Long 객체의 참조 비교가 아닌 값 비교를 위해 equals 메서드 사용 필요

## 작업 내용
- `story.getUserId() != authPayload.getUserId()` → `!story.getUserId().equals(authPayload.getUserId())`
- `story.getHeroId() != user.getRecentHeroNo()` → `!story.getHeroId().equals(user.getRecentHeroNo())`
- Long 객체의 안전한 값 비교를 위해 equals 메서드로 변경

## 참고 사항
- Long 타입의 == / != 연산자는 참조 비교로 예상하지 못한 결과를 낼 수 있음
- equals 메서드를 사용하여 객체의 실제 값을 안전하게 비교
- 코드의 안정성과 예측 가능성 향상

🤖 Generated with [Claude Code](https://claude.ai/code)