### PR TITLE
[SHIP] fix: SecurityConfig에 v1 auth 경로 추가

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/config/SecurityConfig.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(
             (request) -> request.requestMatchers(
-                    "/", "/hc", "/error-test", "/auth/**",
+                    "/", "/hc", "/error-test", "/auth/**", "/v1/auth/**",
                     "/user", "/user/dupcheck/*", "/users", "/users/dupcheck/*",
                     "/v1/user", "/v1/user/dupcheck/*", "/v1/users", "/v1/users/dupcheck/*",
                     "/v3/**", "/question/*", "/questions/*",


### PR DESCRIPTION
## 작업 배경
- auth API에 v1 버전 추가에 따른 보안 설정 누락
- /v1/auth/** 경로가 인증 없이 접근 가능하도록 설정 필요

## 작업 내용
- SecurityConfig에 `/v1/auth/**` 경로 추가
- 기존 `/auth/**` 경로와 동일한 보안 정책 적용
- 인증 없이 접근 가능한 경로 목록에 추가

## 참고 사항
- v1 auth API들이 정상적으로 동작하기 위한 필수 설정
- 기존 auth 경로의 보안 정책과 일관성 유지
- 로그인, 회원가입 등 public API 접근 보장

🤖 Generated with [Claude Code](https://claude.ai/code)