### PR TITLE
[LP-488] feat: AI 생성 비디오 조회 API 및 환경 설정 개선

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -73,7 +73,7 @@ cp .env.example .env
 ```
 
 **Required for Full Stack:**
-- Set your AWS credentials in `.env` file for image-resizer service
+- Set your AWS credentials in .env file for image-resizer service
 - AWS S3 bucket for image storage
 
 ### Default Credentials

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiDrivingVideoEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiDrivingVideoEndpoint.java
@@ -1,21 +1,26 @@
 package io.itmca.lifepuzzle.domain.ai.endpoint;
 
 import io.itmca.lifepuzzle.domain.ai.endpoint.response.AiDrivingVideoResponse;
+import io.itmca.lifepuzzle.domain.ai.endpoint.response.AiGeneratedVideoResponse;
 import io.itmca.lifepuzzle.domain.ai.endpoint.response.dto.AiDrivingVideoDto;
+import io.itmca.lifepuzzle.domain.ai.endpoint.response.dto.AiGeneratedVideoDto;
 import io.itmca.lifepuzzle.domain.ai.service.AiDrivingVideoService;
+import io.itmca.lifepuzzle.domain.ai.service.AiGeneratedVideoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "AI 드라이빙 비디오")
+@Tag(name = "AI 비디오")
 public class AiDrivingVideoEndpoint {
   
   private final AiDrivingVideoService aiDrivingVideoService;
+  private final AiGeneratedVideoService aiGeneratedVideoService;
   
   @Operation(summary = "드라이빙 비디오 목록 조회")
   @GetMapping("/v1/ai/driving-videos")
@@ -23,6 +28,16 @@ public class AiDrivingVideoEndpoint {
     var drivingVideos = aiDrivingVideoService.getAllActiveDrivingVideos();
     var drivingVideoDtos = AiDrivingVideoDto.listFrom(drivingVideos);
     var response = AiDrivingVideoResponse.from(drivingVideoDtos);
+    
+    return ResponseEntity.ok(response);
+  }
+  
+  @Operation(summary = "갤러리 이미지로 생성된 AI 비디오 목록 조회")
+  @GetMapping("/v1/ai/galleries/{galleryId}/generated-videos")
+  public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByGallery(@PathVariable("galleryId") Long galleryId) {
+    var generatedVideos = aiGeneratedVideoService.getGeneratedVideosByGalleryId(galleryId);
+    var generatedVideoDtos = AiGeneratedVideoDto.listFrom(generatedVideos);
+    var response = AiGeneratedVideoResponse.from(generatedVideoDtos);
     
     return ResponseEntity.ok(response);
   }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/AiGeneratedVideoResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/AiGeneratedVideoResponse.java
@@ -1,0 +1,13 @@
+package io.itmca.lifepuzzle.domain.ai.endpoint.response;
+
+import io.itmca.lifepuzzle.domain.ai.endpoint.response.dto.AiGeneratedVideoDto;
+import java.util.List;
+
+public record AiGeneratedVideoResponse(
+    List<AiGeneratedVideoDto> generatedVideos
+) {
+  
+  public static AiGeneratedVideoResponse from(List<AiGeneratedVideoDto> generatedVideos) {
+    return new AiGeneratedVideoResponse(generatedVideos);
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/dto/AiGeneratedVideoDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/response/dto/AiGeneratedVideoDto.java
@@ -1,0 +1,37 @@
+package io.itmca.lifepuzzle.domain.ai.endpoint.response.dto;
+
+import io.itmca.lifepuzzle.domain.ai.entity.AiGeneratedVideo;
+import io.itmca.lifepuzzle.domain.ai.type.VideoGenerationStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AiGeneratedVideoDto(
+    Long id,
+    Long galleryId,
+    Long drivingVideoId,
+    String videoUrl,
+    VideoGenerationStatus status,
+    LocalDateTime startedAt,
+    LocalDateTime completedAt,
+    LocalDateTime createdAt
+) {
+  
+  public static AiGeneratedVideoDto from(AiGeneratedVideo aiGeneratedVideo) {
+    return new AiGeneratedVideoDto(
+        aiGeneratedVideo.getId(),
+        aiGeneratedVideo.getGalleryId(),
+        aiGeneratedVideo.getDrivingVideoId(),
+        aiGeneratedVideo.getVideoUrl(),
+        aiGeneratedVideo.getStatus(),
+        aiGeneratedVideo.getStartedAt(),
+        aiGeneratedVideo.getCompletedAt(),
+        aiGeneratedVideo.getCreatedAt()
+    );
+  }
+  
+  public static List<AiGeneratedVideoDto> listFrom(List<AiGeneratedVideo> aiGeneratedVideos) {
+    return aiGeneratedVideos.stream()
+        .map(AiGeneratedVideoDto::from)
+        .toList();
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/entity/AiGeneratedVideo.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/entity/AiGeneratedVideo.java
@@ -1,0 +1,100 @@
+package io.itmca.lifepuzzle.domain.ai.entity;
+
+import io.itmca.lifepuzzle.domain.ai.type.VideoGenerationStatus;
+import io.itmca.lifepuzzle.domain.content.entity.Gallery;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Table(name = "ai_generated_video")
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AiGeneratedVideo {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  
+  @Column(nullable = false)
+  private Long galleryId;
+  
+  @Column(nullable = false)
+  private Long drivingVideoId;
+  
+  @Setter
+  @Column(length = 500)
+  private String videoUrl;
+  
+  @Setter
+  @Column(nullable = false, length = 20)
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  private VideoGenerationStatus status = VideoGenerationStatus.PENDING;
+  
+  @Setter
+  @Column
+  private LocalDateTime startedAt;
+  
+  @Setter
+  @Column
+  private LocalDateTime completedAt;
+  
+  @Setter
+  @Column(columnDefinition = "TEXT")
+  private String errorMessage;
+  
+  @Column
+  private LocalDateTime deletedAt;
+  
+  @Column(nullable = false, updatable = false)
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+  
+  @Column(nullable = false)
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+  
+  public boolean isDeleted() {
+    return deletedAt != null;
+  }
+  
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
+  
+  public void markAsStarted() {
+    this.status = VideoGenerationStatus.IN_PROGRESS;
+    this.startedAt = LocalDateTime.now();
+  }
+  
+  public void markAsCompleted(String videoUrl) {
+    this.status = VideoGenerationStatus.COMPLETED;
+    this.videoUrl = videoUrl;
+    this.completedAt = LocalDateTime.now();
+  }
+  
+  public void markAsFailed(String errorMessage) {
+    this.status = VideoGenerationStatus.FAILED;
+    this.errorMessage = errorMessage;
+    this.completedAt = LocalDateTime.now();
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiGeneratedVideoRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiGeneratedVideoRepository.java
@@ -1,0 +1,16 @@
+package io.itmca.lifepuzzle.domain.ai.repository;
+
+import io.itmca.lifepuzzle.domain.ai.entity.AiGeneratedVideo;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AiGeneratedVideoRepository extends JpaRepository<AiGeneratedVideo, Long> {
+  
+  @Query("SELECT a FROM AiGeneratedVideo a WHERE a.galleryId = :galleryId AND a.deletedAt IS NULL ORDER BY a.createdAt DESC")
+  List<AiGeneratedVideo> findByGalleryIdAndNotDeleted(@Param("galleryId") Long galleryId);
+  
+  @Query("SELECT a FROM AiGeneratedVideo a WHERE a.deletedAt IS NULL ORDER BY a.createdAt DESC")
+  List<AiGeneratedVideo> findAllActiveOrderByCreatedAtDesc();
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiGeneratedVideoService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiGeneratedVideoService.java
@@ -1,0 +1,24 @@
+package io.itmca.lifepuzzle.domain.ai.service;
+
+import io.itmca.lifepuzzle.domain.ai.entity.AiGeneratedVideo;
+import io.itmca.lifepuzzle.domain.ai.repository.AiGeneratedVideoRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AiGeneratedVideoService {
+  
+  private final AiGeneratedVideoRepository aiGeneratedVideoRepository;
+  
+  public List<AiGeneratedVideo> getGeneratedVideosByGalleryId(Long galleryId) {
+    return aiGeneratedVideoRepository.findByGalleryIdAndNotDeleted(galleryId);
+  }
+  
+  public List<AiGeneratedVideo> getAllGeneratedVideos() {
+    return aiGeneratedVideoRepository.findAllActiveOrderByCreatedAtDesc();
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/type/VideoGenerationStatus.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/type/VideoGenerationStatus.java
@@ -1,0 +1,8 @@
+package io.itmca.lifepuzzle.domain.ai.type;
+
+public enum VideoGenerationStatus {
+  PENDING,     // 대기중
+  IN_PROGRESS, // 진행중
+  COMPLETED,   // 완료
+  FAILED       // 실패
+}

--- a/services/lifepuzzle-api/src/main/resources/application-local.yml
+++ b/services/lifepuzzle-api/src/main/resources/application-local.yml
@@ -6,8 +6,9 @@ spring:
   rabbitmq:
     host: localhost
     port: 5672
-    username: guest
-    password: guest
+    username: lifepuzzle
+    password: lifepuzzlepass
+    virtual-host: lifepuzzle
   cloud:
     stream:
       rabbit:

--- a/services/lifepuzzle-api/src/main/resources/application-local.yml
+++ b/services/lifepuzzle-api/src/main/resources/application-local.yml
@@ -8,7 +8,6 @@ spring:
     port: 5672
     username: lifepuzzle
     password: lifepuzzlepass
-    virtual-host: lifepuzzle
   cloud:
     stream:
       rabbit:

--- a/services/lifepuzzle-api/src/main/resources/application.yml
+++ b/services/lifepuzzle-api/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   profiles:
     active: prod
   datasource:

--- a/services/lifepuzzle-api/src/main/resources/application.yml
+++ b/services/lifepuzzle-api/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: optional:file:.env[.properties]
   profiles:
     active: prod
   datasource:

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `ai_generated_video` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT 'AI 생성 비디오 ID',
+  `gallery_id` BIGINT NOT NULL COMMENT '갤러리(이미지) ID',
+  `driving_video_id` BIGINT NOT NULL COMMENT '드라이빙 비디오 ID',
+  `video_url` VARCHAR(500) COMMENT '생성된 비디오 URL',
+  `status` VARCHAR(20) NOT NULL DEFAULT 'PENDING' COMMENT '생성 상태 (PENDING, IN_PROGRESS, COMPLETED, FAILED)',
+  `started_at` TIMESTAMP NULL COMMENT '생성 시작 시점',
+  `completed_at` TIMESTAMP NULL COMMENT '생성 완료 시점',
+  `error_message` TEXT COMMENT '실패 시 오류 메시지',
+  `deleted_at` TIMESTAMP NULL COMMENT '삭제일시',
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+  
+  FOREIGN KEY (`gallery_id`) REFERENCES `gallery` (`id`),
+  FOREIGN KEY (`driving_video_id`) REFERENCES `ai_driving_video` (`id`)
+) COMMENT 'AI 생성 비디오 테이블';
+
+CREATE INDEX `idx_ai_generated_video_gallery` ON `ai_generated_video` (`gallery_id`, `deleted_at`);
+CREATE INDEX `idx_ai_generated_video_status_created` ON `ai_generated_video` (`status`, `created_at` DESC);


### PR DESCRIPTION
## 작업 배경
- LP-488 티켓: 갤러리 이미지로 생성된 AI 비디오 목록을 조회할 수 있는 API가 필요

## 작업 내용
- AI 생성 비디오 관련 엔티티, 서비스, 리포지토리 구현
- 갤러리 이미지로 생성된 AI 비디오 목록 조회 API 추가 (`/v1/ai/galleries/{galleryId}/generated-videos`)
- 데이터베이스 마이그레이션 스크립트 추가 (ai_generated_video 테이블)
- RabbitMQ 로컬 환경 설정 개선 (사용자명, 패스워드, virtual-host 설정)
- .gitignore 환경 파일 설정 복구

## 참고 사항
- 새로운 API 엔드포인트가 추가되어 API 문서 확인 필요
- 데이터베이스 마이그레이션 실행 후 테스트 권장
- RabbitMQ 설정 변경으로 로컬 환경에서 연결 확인 필요