### PR TITLE
[LP-487] feat: AI 포토 생성 API 추가

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiDrivingVideoEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiDrivingVideoEndpoint.java
@@ -1,5 +1,6 @@
 package io.itmca.lifepuzzle.domain.ai.endpoint;
 
+import io.itmca.lifepuzzle.domain.ai.endpoint.request.AiPhotoGenerateRequest;
 import io.itmca.lifepuzzle.domain.ai.endpoint.response.AiDrivingVideoResponse;
 import io.itmca.lifepuzzle.domain.ai.endpoint.response.AiGeneratedVideoResponse;
 import io.itmca.lifepuzzle.domain.ai.endpoint.response.dto.AiDrivingVideoDto;
@@ -12,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,12 +37,19 @@ public class AiDrivingVideoEndpoint {
   }
   
   @Operation(summary = "갤러리 이미지로 생성된 AI 비디오 목록 조회")
-  @GetMapping("/v1/ai/galleries/{galleryId}/generated-videos")
-  public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByGallery(@PathVariable("galleryId") Long galleryId) {
+  @GetMapping("/v1/ai/videos")
+  public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByGallery(@RequestParam("galleryId") Long galleryId) {
     var generatedVideos = aiGeneratedVideoService.getGeneratedVideosByGalleryId(galleryId);
     var generatedVideoDtos = AiGeneratedVideoDto.listFrom(generatedVideos);
     var response = AiGeneratedVideoResponse.from(generatedVideoDtos);
     
     return ResponseEntity.ok(response);
+  }
+  
+  @Operation(summary = "AI 포토 생성")
+  @PostMapping("/v1/ai/videos")
+  public ResponseEntity<Void> generateAiPhoto(@RequestBody AiPhotoGenerateRequest request) {
+    // TODO: 비즈니스 로직 구현
+    return ResponseEntity.ok().build();
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/request/AiPhotoGenerateRequest.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/request/AiPhotoGenerateRequest.java
@@ -1,0 +1,14 @@
+package io.itmca.lifepuzzle.domain.ai.endpoint.request;
+
+import io.itmca.lifepuzzle.global.aop.HeroNo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AiPhotoGenerateRequest(
+    @HeroNo
+    @Schema(description = "주인공 식별자")
+    Long heroNo,
+    @Schema(description = "갤러리 식별자")
+    Long galleryId,
+    @Schema(description = "드라이빙 비디오 식별자")
+    Long drivingVideoId) {
+}


### PR DESCRIPTION
## 작업 배경
- LP-487 티켓: 갤러리 이미지와 드라이빙 비디오를 이용한 AI 포토 생성 기능 구현 필요

## 작업 내용
- AiPhotoGenerateRequest DTO 생성
  - heroNo 필드에 @HeroNo 어노테이션 적용 (권한 검증)
  - galleryId, drivingVideoId 필드 추가
  - Swagger 문서화 어노테이션 추가
- AI 포토 생성 API 엔드포인트 추가 (POST /v1/ai/videos)
  - 현재는 200 OK만 응답하도록 구현 (비즈니스 로직 TODO)
- 기존 AI 비디오 조회 API 경로 수정 (GET /v1/ai/videos)
  - PathVariable에서 RequestParam으로 변경

## 참고 사항
- 비즈니스 로직은 향후 구현 예정
- @HeroNo 어노테이션을 통한 주인공 권한 검증 적용
- API 문서 자동 생성을 위한 Swagger 어노테이션 포함