### PR TITLE
[SHOW] refactor: AI 포토 API 구조 개선 및 heroNo 기반 조회 지원

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiVideoEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiVideoEndpoint.java
@@ -35,10 +35,10 @@ public class AiVideoEndpoint {
     return ResponseEntity.ok(response);
   }
   
-  @Operation(summary = "갤러리 이미지로 생성된 AI 비디오 목록 조회", description = "특정 갤러리 이미지를 기반으로 생성된 AI 비디오들을 조회합니다")
+  @Operation(summary = "AI 포토 작업 내역 조회", description = "특정 주인공의 AI 포토(비디오) 생성 작업 내역을 조회합니다")
   @GetMapping("/v1/ai/videos")
-  public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByGallery(@RequestParam("galleryId") Long galleryId) {
-    var generatedVideos = aiGeneratedVideoService.getGeneratedVideosByGalleryId(galleryId);
+  public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByHero(@RequestParam("heroId") Long heroId) {
+    var generatedVideos = aiGeneratedVideoService.getGeneratedVideosByHeroId(heroId);
     var generatedVideoDtos = AiGeneratedVideoDto.listFrom(generatedVideos);
     var response = AiGeneratedVideoResponse.from(generatedVideoDtos);
     

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiVideoEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiVideoEndpoint.java
@@ -37,8 +37,8 @@ public class AiVideoEndpoint {
   
   @Operation(summary = "AI 포토 작업 내역 조회", description = "특정 주인공의 AI 포토(비디오) 생성 작업 내역을 조회합니다")
   @GetMapping("/v1/ai/videos")
-  public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByHero(@RequestParam("heroId") Long heroId) {
-    var generatedVideos = aiGeneratedVideoService.getGeneratedVideosByHeroId(heroId);
+  public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByHero(@RequestParam("heroNo") Long heroNo) {
+    var generatedVideos = aiGeneratedVideoService.getGeneratedVideosByHeroNo(heroNo);
     var generatedVideoDtos = AiGeneratedVideoDto.listFrom(generatedVideos);
     var response = AiGeneratedVideoResponse.from(generatedVideoDtos);
     

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiVideoEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/endpoint/AiVideoEndpoint.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,13 +19,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "AI 비디오")
-public class AiDrivingVideoEndpoint {
+@Tag(name = "AI 포토", description = "사진으로 AI 비디오를 생성하는 기능")
+public class AiVideoEndpoint {
   
   private final AiDrivingVideoService aiDrivingVideoService;
   private final AiGeneratedVideoService aiGeneratedVideoService;
   
-  @Operation(summary = "드라이빙 비디오 목록 조회")
+  @Operation(summary = "드라이빙 비디오 목록 조회", description = "사용 가능한 드라이빙 비디오 템플릿 목록을 조회합니다")
   @GetMapping("/v1/ai/driving-videos")
   public ResponseEntity<AiDrivingVideoResponse> getDrivingVideos() {
     var drivingVideos = aiDrivingVideoService.getAllActiveDrivingVideos();
@@ -36,7 +35,7 @@ public class AiDrivingVideoEndpoint {
     return ResponseEntity.ok(response);
   }
   
-  @Operation(summary = "갤러리 이미지로 생성된 AI 비디오 목록 조회")
+  @Operation(summary = "갤러리 이미지로 생성된 AI 비디오 목록 조회", description = "특정 갤러리 이미지를 기반으로 생성된 AI 비디오들을 조회합니다")
   @GetMapping("/v1/ai/videos")
   public ResponseEntity<AiGeneratedVideoResponse> getGeneratedVideosByGallery(@RequestParam("galleryId") Long galleryId) {
     var generatedVideos = aiGeneratedVideoService.getGeneratedVideosByGalleryId(galleryId);
@@ -46,10 +45,10 @@ public class AiDrivingVideoEndpoint {
     return ResponseEntity.ok(response);
   }
   
-  @Operation(summary = "AI 포토 생성")
+  @Operation(summary = "AI 포토 생성", description = "업로드된 사진을 기반으로 AI 비디오를 생성합니다")
   @PostMapping("/v1/ai/videos")
-  public ResponseEntity<Void> generateAiPhoto(@RequestBody AiPhotoGenerateRequest request) {
-    // TODO: 비즈니스 로직 구현
+  public ResponseEntity<Void> generateAiVideo(@RequestBody AiPhotoGenerateRequest request) {
+    // TODO: AI 비디오 생성 비즈니스 로직 구현
     return ResponseEntity.ok().build();
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/entity/AiGeneratedVideo.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/entity/AiGeneratedVideo.java
@@ -35,6 +35,9 @@ public class AiGeneratedVideo {
   private Long id;
   
   @Column(nullable = false)
+  private Long heroNo;
+
+  @Column(nullable = false)
   private Long galleryId;
   
   @Column(nullable = false)

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiGeneratedVideoRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiGeneratedVideoRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 public interface AiGeneratedVideoRepository extends JpaRepository<AiGeneratedVideo, Long> {
   
   @Query("SELECT a FROM AiGeneratedVideo a WHERE a.heroNo = :heroNo AND a.deletedAt IS NULL ORDER BY a.createdAt DESC")
-  List<AiGeneratedVideo> findByHeroIdAndNotDeleted(@Param("heroNo") Long heroNo);
+  List<AiGeneratedVideo> findByHeroNoAndNotDeleted(@Param("heroNo") Long heroNo);
   
   @Query("SELECT a FROM AiGeneratedVideo a WHERE a.deletedAt IS NULL ORDER BY a.createdAt DESC")
   List<AiGeneratedVideo> findAllActiveOrderByCreatedAtDesc();

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiGeneratedVideoRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/repository/AiGeneratedVideoRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface AiGeneratedVideoRepository extends JpaRepository<AiGeneratedVideo, Long> {
   
-  @Query("SELECT a FROM AiGeneratedVideo a WHERE a.galleryId = :galleryId AND a.deletedAt IS NULL ORDER BY a.createdAt DESC")
-  List<AiGeneratedVideo> findByGalleryIdAndNotDeleted(@Param("galleryId") Long galleryId);
+  @Query("SELECT a FROM AiGeneratedVideo a WHERE a.heroNo = :heroNo AND a.deletedAt IS NULL ORDER BY a.createdAt DESC")
+  List<AiGeneratedVideo> findByHeroIdAndNotDeleted(@Param("heroNo") Long heroNo);
   
   @Query("SELECT a FROM AiGeneratedVideo a WHERE a.deletedAt IS NULL ORDER BY a.createdAt DESC")
   List<AiGeneratedVideo> findAllActiveOrderByCreatedAtDesc();

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiGeneratedVideoService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiGeneratedVideoService.java
@@ -14,8 +14,8 @@ public class AiGeneratedVideoService {
   
   private final AiGeneratedVideoRepository aiGeneratedVideoRepository;
   
-  public List<AiGeneratedVideo> getGeneratedVideosByGalleryId(Long galleryId) {
-    return aiGeneratedVideoRepository.findByGalleryIdAndNotDeleted(galleryId);
+  public List<AiGeneratedVideo> getGeneratedVideosByHeroId(Long heroId) {
+    return aiGeneratedVideoRepository.findByHeroIdAndNotDeleted(heroId);
   }
   
   public List<AiGeneratedVideo> getAllGeneratedVideos() {

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiGeneratedVideoService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/ai/service/AiGeneratedVideoService.java
@@ -14,8 +14,8 @@ public class AiGeneratedVideoService {
   
   private final AiGeneratedVideoRepository aiGeneratedVideoRepository;
   
-  public List<AiGeneratedVideo> getGeneratedVideosByHeroId(Long heroId) {
-    return aiGeneratedVideoRepository.findByHeroIdAndNotDeleted(heroId);
+  public List<AiGeneratedVideo> getGeneratedVideosByHeroNo(Long heroNo) {
+    return aiGeneratedVideoRepository.findByHeroNoAndNotDeleted(heroNo);
   }
   
   public List<AiGeneratedVideo> getAllGeneratedVideos() {

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE `ai_generated_video` (
   `id` BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT 'AI 생성 비디오 ID',
+  `hero_no` BIGINT NOT NULL COMMENT '주인공 식별자',
   `gallery_id` BIGINT NOT NULL COMMENT '갤러리(이미지) ID',
   `driving_video_id` BIGINT NOT NULL COMMENT '드라이빙 비디오 ID',
   `video_url` VARCHAR(500) COMMENT '생성된 비디오 URL',
@@ -10,10 +11,14 @@ CREATE TABLE `ai_generated_video` (
   `deleted_at` TIMESTAMP NULL COMMENT '삭제일시',
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
   `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
-  
+
   FOREIGN KEY (`gallery_id`) REFERENCES `gallery` (`id`),
   FOREIGN KEY (`driving_video_id`) REFERENCES `ai_driving_video` (`id`)
 ) COMMENT 'AI 생성 비디오 테이블';
 
-CREATE INDEX `idx_ai_generated_video_gallery` ON `ai_generated_video` (`gallery_id`, `deleted_at`);
+-- 주인공별 조회용 인덱스 (deleted_at 조건은 애플리케이션에서 처리)
+CREATE INDEX `idx_ai_generated_video_hero_no` ON `ai_generated_video` (`hero_no`);
+-- 갤러리별 조회용 인덱스 (필요시)
+CREATE INDEX `idx_ai_generated_video_gallery` ON `ai_generated_video` (`gallery_id`);
+-- 상태별 정렬 조회용 인덱스
 CREATE INDEX `idx_ai_generated_video_status_created` ON `ai_generated_video` (`status`, `created_at` DESC);

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
@@ -18,5 +18,3 @@ CREATE TABLE `ai_generated_video` (
 
 -- 주인공별 조회용 인덱스 (soft delete 필터링 포함)
 CREATE INDEX `idx_ai_generated_video_hero_no` ON `ai_generated_video` (`hero_no`, `deleted_at`);
--- 상태별 정렬 조회용 인덱스
-CREATE INDEX `idx_ai_generated_video_status_created` ON `ai_generated_video` (`status`, `created_at` DESC);

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
@@ -16,9 +16,7 @@ CREATE TABLE `ai_generated_video` (
   FOREIGN KEY (`driving_video_id`) REFERENCES `ai_driving_video` (`id`)
 ) COMMENT 'AI 생성 비디오 테이블';
 
--- 주인공별 조회용 인덱스 (deleted_at 조건은 애플리케이션에서 처리)
-CREATE INDEX `idx_ai_generated_video_hero_no` ON `ai_generated_video` (`hero_no`);
--- 갤러리별 조회용 인덱스 (필요시)
-CREATE INDEX `idx_ai_generated_video_gallery` ON `ai_generated_video` (`gallery_id`);
+-- 주인공별 조회용 인덱스 (soft delete 필터링 포함)
+CREATE INDEX `idx_ai_generated_video_hero_no` ON `ai_generated_video` (`hero_no`, `deleted_at`);
 -- 상태별 정렬 조회용 인덱스
 CREATE INDEX `idx_ai_generated_video_status_created` ON `ai_generated_video` (`status`, `created_at` DESC);

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V2__create_ai_generated_video_table.sql
@@ -10,10 +10,7 @@ CREATE TABLE `ai_generated_video` (
   `error_message` TEXT COMMENT '실패 시 오류 메시지',
   `deleted_at` TIMESTAMP NULL COMMENT '삭제일시',
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
-  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
-
-  FOREIGN KEY (`gallery_id`) REFERENCES `gallery` (`id`),
-  FOREIGN KEY (`driving_video_id`) REFERENCES `ai_driving_video` (`id`)
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시'
 ) COMMENT 'AI 생성 비디오 테이블';
 
 -- 주인공별 조회용 인덱스 (soft delete 필터링 포함)

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_hero_no_to_ai_generated_video.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_hero_no_to_ai_generated_video.sql
@@ -1,8 +1,0 @@
--- AI 생성 비디오 테이블에 hero_no 컬럼 추가
-ALTER TABLE `ai_generated_video`
-ADD COLUMN `hero_no` BIGINT NOT NULL COMMENT '주인공 식별자' AFTER `id`;
-
--- hero_no를 기준으로 조회할 인덱스 추가
-CREATE INDEX `idx_ai_generated_video_hero_no` ON `ai_generated_video` (`hero_no`, `deleted_at`);
-
--- 기존 gallery_id 기준 인덱스는 유지 (갤러리별 조회도 필요할 수 있음)

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_hero_no_to_ai_generated_video.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_hero_no_to_ai_generated_video.sql
@@ -1,0 +1,8 @@
+-- AI 생성 비디오 테이블에 hero_no 컬럼 추가
+ALTER TABLE `ai_generated_video`
+ADD COLUMN `hero_no` BIGINT NOT NULL COMMENT '주인공 식별자' AFTER `id`;
+
+-- hero_no를 기준으로 조회할 인덱스 추가
+CREATE INDEX `idx_ai_generated_video_hero_no` ON `ai_generated_video` (`hero_no`, `deleted_at`);
+
+-- 기존 gallery_id 기준 인덱스는 유지 (갤러리별 조회도 필요할 수 있음)


### PR DESCRIPTION
## 작업 배경
- 사용자 기능명("AI 포토")과 백엔드 클래스명의 일관성 개선 필요  
- AiPhotoGenerateRequest에 heroNo가 있지만 작업 내역 조회가 galleryId 기반으로 되어 있는 문제
- DB 스키마 및 인덱스 최적화 필요

## 작업 내용

### 1. 클래스명 및 API 설명 개선
- **클래스명 변경**: `AiDrivingVideoEndpoint` → `AiVideoEndpoint`
- **Tag 정리**: "AI 포토(비디오)" → "AI 포토"로 통일하고 설명 추가
- **메서드명 일관성**: `generateAiPhoto` → `generateAiVideo`, `getGeneratedVideosByGallery` → `getGeneratedVideosByHero`
- **Operation 설명 개선**: 각 API에 상세 description 추가

### 2. heroNo 기반 조회 지원
- **DB 스키마**: `ai_generated_video` 테이블에 `hero_no` 컬럼 추가
- **엔티티 업데이트**: `AiGeneratedVideo`에 `heroNo` 필드 추가
- **Repository/Service 수정**: `heroNo` 기반 조회로 변경 (`findByHeroNoAndNotDeleted`)
- **API 파라미터**: `heroNo`로 조회하도록 일관성 개선

### 3. DB 스키마 및 성능 최적화
- **Flyway 마이그레이션 통합**: V2와 V3를 하나로 합쳐 깔끔한 구조
- **인덱스 최적화**: 
  - `(hero_no, deleted_at)` 복합 인덱스로 주요 조회 패턴 최적화
  - 불필요한 `gallery_id`, `status` 인덱스 제거
- **Foreign Key 제거**: 기존 정책과 일관성 유지 및 성능 최적화
- **RabbitMQ 기반 작업 처리**에 맞춘 최적화

## 최종 테이블 구조
```sql
CREATE TABLE `ai_generated_video` (
  `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
  `hero_no` BIGINT NOT NULL COMMENT '주인공 식별자',
  `gallery_id` BIGINT NOT NULL COMMENT '갤러리(이미지) ID',
  `driving_video_id` BIGINT NOT NULL COMMENT '드라이빙 비디오 ID',
  -- ... 기타 컬럼들
);

-- 최적화된 단일 인덱스
CREATE INDEX `idx_ai_generated_video_hero_no` ON `ai_generated_video` (`hero_no`, `deleted_at`);
```

## 참고 사항
- **API 호환성**: `/v1/ai/videos?heroNo=xxx` API로 변경
- **배포 전 작업**: 기존 `ai_generated_video` 테이블과 flyway_schema_history에서 V2 기록 삭제 필요
- **성능**: 불필요한 제약 조건 및 인덱스 제거로 INSERT/UPDATE 성능 향상
- **확장성**: 필요시 갤러리별, 상태별 인덱스 추후 추가 가능

🤖 Generated with [Claude Code](https://claude.ai/code)