### PR TITLE
Add Facebook photo import and deletion flow

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/FacebookOAuthEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/FacebookOAuthEndpoint.java
@@ -15,13 +15,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/FacebookOAuthEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/FacebookOAuthEndpoint.java
@@ -1,15 +1,28 @@
 package io.itmca.lifepuzzle.domain.auth.endpoint;
 
+import io.itmca.lifepuzzle.domain.auth.endpoint.request.FacebookPhotoImportRequest;
+import io.itmca.lifepuzzle.domain.auth.endpoint.response.FacebookDataDeletionResponse;
+import io.itmca.lifepuzzle.domain.auth.endpoint.response.FacebookDataDeletionStatusResponse;
+import io.itmca.lifepuzzle.domain.auth.endpoint.response.FacebookPhotoImportResponse;
 import io.itmca.lifepuzzle.domain.auth.endpoint.response.FacebookPhotosResponse;
+import io.itmca.lifepuzzle.domain.auth.jwt.AuthPayload;
+import io.itmca.lifepuzzle.domain.auth.service.FacebookDataDeletionService;
 import io.itmca.lifepuzzle.domain.auth.service.FacebookOAuthService;
+import io.itmca.lifepuzzle.domain.auth.service.FacebookPhotoImportService;
 import io.itmca.lifepuzzle.domain.auth.service.FacebookPhotoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,12 +30,40 @@ import org.springframework.web.bind.annotation.RestController;
 public class FacebookOAuthEndpoint {
   private final FacebookOAuthService facebookOAuthService;
   private final FacebookPhotoService facebookPhotoService;
+  private final FacebookDataDeletionService facebookDataDeletionService;
+  private final FacebookPhotoImportService facebookPhotoImportService;
 
   @Operation(summary = "Facebook 사진 목록 조회")
   @GetMapping("/v1/facebook/photos")
-  public ResponseEntity<FacebookPhotosResponse> getFacebookPhotos(@RequestParam String code) {
+  public ResponseEntity<FacebookPhotosResponse> getFacebookPhotos(
+      @RequestParam String code,
+      @AuthenticationPrincipal AuthPayload authPayload
+  ) {
+    if (authPayload == null) {
+      throw new AccessDeniedException("Authentication is required.");
+    }
     var accessToken = facebookOAuthService.getAccessToken(code);
     var response = facebookPhotoService.getFilteredUserPhotos(accessToken);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "Facebook 사진 1회성 가져오기", description = "Facebook 사진을 가져와 갤러리에 저장합니다.")
+  @PostMapping("/v1/facebook/photos/import")
+  public ResponseEntity<FacebookPhotoImportResponse> importFacebookPhotos(
+      @RequestBody FacebookPhotoImportRequest request,
+      @AuthenticationPrincipal AuthPayload authPayload
+  ) {
+    if (authPayload == null) {
+      throw new AccessDeniedException("Authentication is required.");
+    }
+
+    var response = facebookPhotoImportService.importPhotos(
+        authPayload.getUserId(),
+        request.code(),
+        request.heroNo(),
+        request.ageGroup()
+    );
 
     return ResponseEntity.ok(response);
   }
@@ -31,5 +72,28 @@ public class FacebookOAuthEndpoint {
   @GetMapping("/v1/facebook/callback")
   public ResponseEntity<String> facebookOAuthCallback(@RequestParam String code) {
     return ResponseEntity.ok("Facebook OAuth 인증이 완료되었습니다.");
+  }
+
+  @Operation(summary = "Facebook 데이터 삭제 콜백", description = "Facebook 데이터 삭제 요청을 처리하고 확인 코드를 반환합니다.")
+  @PostMapping(value = "/v1/facebook/data-deletion", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+  public ResponseEntity<FacebookDataDeletionResponse> facebookDataDeletionCallback(
+      @RequestParam("signed_request") String signedRequest
+  ) {
+    var confirmationCode = facebookDataDeletionService.processSignedRequest(signedRequest);
+    var statusUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+        .path("/v1/facebook/data-deletion/status")
+        .queryParam("code", confirmationCode)
+        .toUriString();
+    var response = new FacebookDataDeletionResponse(statusUrl, confirmationCode);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "Facebook 데이터 삭제 상태 조회", description = "Facebook 데이터 삭제 요청 상태를 확인합니다.")
+  @GetMapping("/v1/facebook/data-deletion/status")
+  public ResponseEntity<FacebookDataDeletionStatusResponse> facebookDataDeletionStatus(
+      @RequestParam("code") String code
+  ) {
+    return ResponseEntity.ok(new FacebookDataDeletionStatusResponse(code, "received"));
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/request/FacebookPhotoImportRequest.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/request/FacebookPhotoImportRequest.java
@@ -1,0 +1,9 @@
+package io.itmca.lifepuzzle.domain.auth.endpoint.request;
+
+import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
+
+public record FacebookPhotoImportRequest(
+    String code,
+    Long heroNo,
+    AgeGroup ageGroup
+) {}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/response/FacebookDataDeletionResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/response/FacebookDataDeletionResponse.java
@@ -1,0 +1,8 @@
+package io.itmca.lifepuzzle.domain.auth.endpoint.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FacebookDataDeletionResponse(
+    String url,
+    @JsonProperty("confirmation_code") String confirmationCode
+) {}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/response/FacebookDataDeletionStatusResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/response/FacebookDataDeletionStatusResponse.java
@@ -1,0 +1,6 @@
+package io.itmca.lifepuzzle.domain.auth.endpoint.response;
+
+public record FacebookDataDeletionStatusResponse(
+    String code,
+    String status
+) {}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/response/FacebookPhotoImportResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/endpoint/response/FacebookPhotoImportResponse.java
@@ -1,0 +1,5 @@
+package io.itmca.lifepuzzle.domain.auth.endpoint.response;
+
+public record FacebookPhotoImportResponse(
+    int importedCount
+) {}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/oauth/response/FacebookUserResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/oauth/response/FacebookUserResponse.java
@@ -1,0 +1,5 @@
+package io.itmca.lifepuzzle.domain.auth.oauth.response;
+
+public record FacebookUserResponse(
+    String id
+) {}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookDataDeletionService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookDataDeletionService.java
@@ -1,0 +1,120 @@
+package io.itmca.lifepuzzle.domain.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.itmca.lifepuzzle.domain.auth.service.dto.FacebookSignedRequestPayload;
+import io.itmca.lifepuzzle.domain.content.repository.GalleryRepository;
+import io.itmca.lifepuzzle.domain.content.type.GallerySource;
+import io.itmca.lifepuzzle.domain.user.repository.UserRepository;
+import io.itmca.lifepuzzle.global.exception.InvalidSignedRequestException;
+import io.itmca.lifepuzzle.global.file.service.S3UploadService;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FacebookDataDeletionService {
+  private static final String SIGNATURE_ALGORITHM = "HmacSHA256";
+  private static final String EXPECTED_ALGORITHM = "HMAC-SHA256";
+
+  private final ObjectMapper objectMapper;
+  private final UserRepository userRepository;
+  private final GalleryRepository galleryRepository;
+  private final S3UploadService s3UploadService;
+
+  @Value("${facebook.client-secret}")
+  private String clientSecret;
+
+  @Transactional
+  public String processSignedRequest(String signedRequest) {
+    if (signedRequest == null || signedRequest.isBlank()) {
+      throw new InvalidSignedRequestException();
+    }
+
+    var parts = signedRequest.split("\\.", 2);
+    if (parts.length != 2) {
+      throw new InvalidSignedRequestException();
+    }
+
+    var signature = decodeUrlBase64(parts[0]);
+    var payloadBytes = decodeUrlBase64(parts[1]);
+    var expectedSignature = hmacSha256(payloadBytes);
+
+    if (!MessageDigest.isEqual(signature, expectedSignature)) {
+      throw new AccessDeniedException("Invalid signed_request signature.");
+    }
+
+    var payload = parsePayload(payloadBytes);
+    if (!EXPECTED_ALGORITHM.equals(payload.algorithm())) {
+      throw new AccessDeniedException("Unsupported signed_request algorithm.");
+    }
+
+    if (payload.userId() == null || payload.userId().isBlank()) {
+      throw new InvalidSignedRequestException();
+    }
+
+    deleteFacebookData(payload.userId());
+
+    return generateConfirmationCode(payload.userId());
+  }
+
+  private byte[] decodeUrlBase64(String encoded) {
+    try {
+      return Base64.getUrlDecoder().decode(encoded);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidSignedRequestException();
+    }
+  }
+
+  private byte[] hmacSha256(byte[] payload) {
+    try {
+      var mac = Mac.getInstance(SIGNATURE_ALGORITHM);
+      var keySpec = new SecretKeySpec(clientSecret.getBytes(StandardCharsets.UTF_8), SIGNATURE_ALGORITHM);
+      mac.init(keySpec);
+      return mac.doFinal(payload);
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+      throw new IllegalStateException("Failed to verify signed_request.", e);
+    }
+  }
+
+  private FacebookSignedRequestPayload parsePayload(byte[] payloadBytes) {
+    try {
+      return objectMapper.readValue(payloadBytes, FacebookSignedRequestPayload.class);
+    } catch (Exception e) {
+      throw new InvalidSignedRequestException();
+    }
+  }
+
+  private String generateConfirmationCode(String userId) {
+    var source = userId + ":" + UUID.randomUUID();
+    return UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8)).toString();
+  }
+
+  private void deleteFacebookData(String facebookUserId) {
+    var userOpt = userRepository.findByFacebookUserId(facebookUserId);
+    if (userOpt.isEmpty()) {
+      return;
+    }
+
+    var user = userOpt.get();
+    var galleries = galleryRepository.findAllBySourceAndUploadedUserId(GallerySource.FACEBOOK, user.getId());
+    for (var gallery : galleries) {
+      if (gallery.getUrl() != null && !gallery.getUrl().isBlank()) {
+        s3UploadService.delete(gallery.getUrl());
+      }
+    }
+    galleryRepository.deleteAll(galleries);
+
+    user.setFacebookUserId(null);
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookDataDeletionService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookDataDeletionService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.itmca.lifepuzzle.domain.auth.service.dto.FacebookSignedRequestPayload;
 import io.itmca.lifepuzzle.domain.content.repository.GalleryRepository;
 import io.itmca.lifepuzzle.domain.content.type.GallerySource;
-import io.itmca.lifepuzzle.domain.user.repository.UserRepository;
+import io.itmca.lifepuzzle.domain.hero.repository.HeroRepository;
 import io.itmca.lifepuzzle.global.exception.InvalidSignedRequestException;
 import io.itmca.lifepuzzle.global.file.service.S3UploadService;
 import java.nio.charset.StandardCharsets;
@@ -28,7 +28,7 @@ public class FacebookDataDeletionService {
   private static final String EXPECTED_ALGORITHM = "HMAC-SHA256";
 
   private final ObjectMapper objectMapper;
-  private final UserRepository userRepository;
+  private final HeroRepository heroRepository;
   private final GalleryRepository galleryRepository;
   private final S3UploadService s3UploadService;
 
@@ -101,13 +101,13 @@ public class FacebookDataDeletionService {
   }
 
   private void deleteFacebookData(String facebookUserId) {
-    var userOpt = userRepository.findByFacebookUserId(facebookUserId);
-    if (userOpt.isEmpty()) {
+    var heroOpt = heroRepository.findByFacebookUserId(facebookUserId);
+    if (heroOpt.isEmpty()) {
       return;
     }
 
-    var user = userOpt.get();
-    var galleries = galleryRepository.findAllBySourceAndUploadedUserId(GallerySource.FACEBOOK, user.getId());
+    var hero = heroOpt.get();
+    var galleries = galleryRepository.findAllByHeroIdAndSource(hero.getHeroNo(), GallerySource.FACEBOOK);
     for (var gallery : galleries) {
       if (gallery.getUrl() != null && !gallery.getUrl().isBlank()) {
         s3UploadService.delete(gallery.getUrl());
@@ -115,6 +115,6 @@ public class FacebookDataDeletionService {
     }
     galleryRepository.deleteAll(galleries);
 
-    user.setFacebookUserId(null);
+    hero.setFacebookUserId(null);
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookOAuthService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookOAuthService.java
@@ -1,6 +1,7 @@
 package io.itmca.lifepuzzle.domain.auth.service;
 
 import io.itmca.lifepuzzle.domain.auth.oauth.response.FacebookTokenResponse;
+import io.itmca.lifepuzzle.domain.auth.oauth.response.FacebookUserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class FacebookOAuthService {
   private String redirectUri;
 
   private static final String TOKEN_PATH = "/oauth/access_token";
+  private static final String ME_PATH = "/me";
 
   public String getAccessToken(String code) {
     return restClient.get()
@@ -33,5 +35,16 @@ public class FacebookOAuthService {
         .body(FacebookTokenResponse.class)
         .accessToken();
   }
-}
 
+  public String getUserId(String accessToken) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path(ME_PATH)
+            .queryParam("fields", "id")
+            .queryParam("access_token", accessToken)
+            .build())
+        .retrieve()
+        .body(FacebookUserResponse.class)
+        .id();
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookPhotoImportService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookPhotoImportService.java
@@ -4,10 +4,10 @@ import io.itmca.lifepuzzle.domain.auth.endpoint.response.FacebookPhotoImportResp
 import io.itmca.lifepuzzle.domain.content.service.GalleryWriteService;
 import io.itmca.lifepuzzle.domain.content.service.GalleryWriteService.FacebookImportPhoto;
 import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
-import io.itmca.lifepuzzle.domain.user.repository.UserRepository;
+import io.itmca.lifepuzzle.domain.hero.repository.HeroRepository;
 import io.itmca.lifepuzzle.global.exception.FacebookUserAlreadyLinkedException;
+import io.itmca.lifepuzzle.global.exception.HeroNotFoundException;
 import io.itmca.lifepuzzle.global.exception.MissingHeroNoException;
-import io.itmca.lifepuzzle.global.exception.UserNotFoundException;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class FacebookPhotoImportService {
   private final FacebookOAuthService facebookOAuthService;
   private final FacebookPhotoService facebookPhotoService;
   private final GalleryWriteService galleryWriteService;
-  private final UserRepository userRepository;
+  private final HeroRepository heroRepository;
 
   @Transactional
   public FacebookPhotoImportResponse importPhotos(Long userId, String code, Long heroNo, AgeGroup ageGroup) {
@@ -32,15 +32,15 @@ public class FacebookPhotoImportService {
     var accessToken = facebookOAuthService.getAccessToken(code);
     var facebookUserId = facebookOAuthService.getUserId(accessToken);
 
-    userRepository.findByFacebookUserId(facebookUserId)
-        .filter(existing -> !existing.getId().equals(userId))
+    heroRepository.findByFacebookUserId(facebookUserId)
+        .filter(existing -> !existing.getHeroNo().equals(heroNo))
         .ifPresent(existing -> {
           throw new FacebookUserAlreadyLinkedException(facebookUserId);
         });
 
-    var user = userRepository.findById(userId)
-        .orElseThrow(() -> UserNotFoundException.byUserNo(userId));
-    user.setFacebookUserId(facebookUserId);
+    var hero = heroRepository.findById(heroNo)
+        .orElseThrow(() -> HeroNotFoundException.byHeroNo(heroNo));
+    hero.setFacebookUserId(facebookUserId);
 
     var photosResponse = facebookPhotoService.getFilteredUserPhotos(accessToken);
     List<FacebookImportPhoto> photos = photosResponse.photos().stream()

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookPhotoImportService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/FacebookPhotoImportService.java
@@ -1,0 +1,83 @@
+package io.itmca.lifepuzzle.domain.auth.service;
+
+import io.itmca.lifepuzzle.domain.auth.endpoint.response.FacebookPhotoImportResponse;
+import io.itmca.lifepuzzle.domain.content.service.GalleryWriteService;
+import io.itmca.lifepuzzle.domain.content.service.GalleryWriteService.FacebookImportPhoto;
+import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
+import io.itmca.lifepuzzle.domain.user.repository.UserRepository;
+import io.itmca.lifepuzzle.global.exception.FacebookUserAlreadyLinkedException;
+import io.itmca.lifepuzzle.global.exception.MissingHeroNoException;
+import io.itmca.lifepuzzle.global.exception.UserNotFoundException;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class FacebookPhotoImportService {
+  private final FacebookOAuthService facebookOAuthService;
+  private final FacebookPhotoService facebookPhotoService;
+  private final GalleryWriteService galleryWriteService;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public FacebookPhotoImportResponse importPhotos(Long userId, String code, Long heroNo, AgeGroup ageGroup) {
+    if (heroNo == null) {
+      throw new MissingHeroNoException();
+    }
+
+    var accessToken = facebookOAuthService.getAccessToken(code);
+    var facebookUserId = facebookOAuthService.getUserId(accessToken);
+
+    userRepository.findByFacebookUserId(facebookUserId)
+        .filter(existing -> !existing.getId().equals(userId))
+        .ifPresent(existing -> {
+          throw new FacebookUserAlreadyLinkedException(facebookUserId);
+        });
+
+    var user = userRepository.findById(userId)
+        .orElseThrow(() -> UserNotFoundException.byUserNo(userId));
+    user.setFacebookUserId(facebookUserId);
+
+    var photosResponse = facebookPhotoService.getFilteredUserPhotos(accessToken);
+    List<FacebookImportPhoto> photos = photosResponse.photos().stream()
+        .map(photo -> toImportPhoto(photo.imageUrl()))
+        .toList();
+
+    var saved = galleryWriteService.saveFacebookGallery(heroNo, userId, photos, ageGroup);
+    return new FacebookPhotoImportResponse(saved.size());
+  }
+
+  private FacebookImportPhoto toImportPhoto(String imageUrl) {
+    var bytes = RestClient.create().get()
+        .uri(imageUrl)
+        .retrieve()
+        .body(byte[].class);
+    if (bytes == null) {
+      return new FacebookImportPhoto("download-failed.jpg", new byte[0]);
+    }
+
+    return new FacebookImportPhoto(resolveFileName(imageUrl), bytes);
+  }
+
+  private String resolveFileName(String imageUrl) {
+    try {
+      var uri = URI.create(imageUrl);
+      var path = uri.getPath();
+      if (path == null || path.isBlank()) {
+        return "facebook.jpg";
+      }
+
+      var fileName = path.substring(path.lastIndexOf('/') + 1);
+      if (!fileName.contains(".")) {
+        return fileName + ".jpg";
+      }
+      return fileName;
+    } catch (Exception e) {
+      return "facebook.jpg";
+    }
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/dto/FacebookSignedRequestPayload.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/auth/service/dto/FacebookSignedRequestPayload.java
@@ -1,0 +1,9 @@
+package io.itmca.lifepuzzle.domain.auth.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FacebookSignedRequestPayload(
+    String algorithm,
+    @JsonProperty("issued_at") Long issuedAt,
+    @JsonProperty("user_id") String userId
+) {}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/GalleryDto.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/endpoint/response/dto/GalleryDto.java
@@ -7,6 +7,7 @@ import static io.itmca.lifepuzzle.global.constants.FileConstant.STORY_IMAGE_RESI
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.itmca.lifepuzzle.domain.content.entity.Gallery;
 import io.itmca.lifepuzzle.domain.content.entity.StoryGallery;
+import io.itmca.lifepuzzle.domain.content.type.GallerySource;
 import io.itmca.lifepuzzle.domain.content.type.GalleryType;
 import java.time.LocalDate;
 
@@ -15,6 +16,7 @@ public record GalleryDto(
     Long id,
     int index,
     GalleryType type,
+    GallerySource source,
     LocalDate date,
     String url,
     String thumbnailUrl,
@@ -33,6 +35,7 @@ public record GalleryDto(
         gallery.getId(),
         index,
         gallery.getGalleryType(),
+        gallery.getSource(),
         gallery.getDate(),
         gallery.getImageUrl(STORY_IMAGE_RESIZING_GENERAL_WIDTH),
         gallery.getImageUrl(STORY_IMAGE_RESIZING_THUMBNAIL_WIDTH),

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/GalleryRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/GalleryRepository.java
@@ -1,6 +1,7 @@
 package io.itmca.lifepuzzle.domain.content.repository;
 
 import io.itmca.lifepuzzle.domain.content.entity.Gallery;
+import io.itmca.lifepuzzle.domain.content.type.GallerySource;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,8 @@ public interface GalleryRepository extends JpaRepository<Gallery, Long> {
   Optional<Gallery> findByUrl(String url);
 
   Optional<Gallery> findByIdAndHeroId(Long id, Long heroId);
+
+  List<Gallery> findAllBySourceAndUploadedUserId(GallerySource source, Long uploadedUserId);
 
   @Query("SELECT g FROM Gallery g "
          + "LEFT JOIN FETCH g.storyMaps sm "

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/GalleryRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/repository/GalleryRepository.java
@@ -19,6 +19,8 @@ public interface GalleryRepository extends JpaRepository<Gallery, Long> {
 
   List<Gallery> findAllBySourceAndUploadedUserId(GallerySource source, Long uploadedUserId);
 
+  List<Gallery> findAllByHeroIdAndSource(Long heroId, GallerySource source);
+
   @Query("SELECT g FROM Gallery g "
          + "LEFT JOIN FETCH g.storyMaps sm "
          + "LEFT JOIN FETCH sm.story "

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/GalleryWriteService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/GalleryWriteService.java
@@ -8,7 +8,10 @@ import io.itmca.lifepuzzle.domain.content.endpoint.response.dto.GalleryUploadRes
 import io.itmca.lifepuzzle.domain.content.entity.Gallery;
 import io.itmca.lifepuzzle.domain.content.event.PhotoUploadEventPublisher;
 import io.itmca.lifepuzzle.domain.content.repository.GalleryRepository;
+import static io.itmca.lifepuzzle.global.constants.FileConstant.NEW_STORY_IMAGE_BASE_PATH_FORMAT;
+
 import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
+import io.itmca.lifepuzzle.domain.content.type.GallerySource;
 import io.itmca.lifepuzzle.domain.content.type.GalleryStatus;
 import io.itmca.lifepuzzle.global.exception.GalleryItemNotFoundException;
 import io.itmca.lifepuzzle.global.file.domain.StoryImageFile;
@@ -48,6 +51,46 @@ public class GalleryWriteService {
     // Publish photo upload events to RabbitMQ for image resizing
     publishPhotoUploadEvents(saveGalleryFiles, heroId);
   }
+
+  @Transactional
+  public List<Gallery> saveFacebookGallery(Long heroId, Long uploadedUserId,
+                                           List<FacebookImportPhoto> photos, AgeGroup ageGroup) {
+    var correctedAgeGroup = AgeGroup.orUncategorized(ageGroup);
+    var validPhotos = photos.stream()
+        .filter(photo -> photo != null && photo.bytes() != null && photo.bytes().length > 0)
+        .toList();
+    var galleries = validPhotos.stream()
+        .map(photo -> Gallery.builder()
+            .heroId(heroId)
+            .ageGroup(correctedAgeGroup)
+            .galleryType(IMAGE)
+            .source(GallerySource.FACEBOOK)
+            .galleryStatus(GalleryStatus.UPLOADED)
+            .uploadedUserId(uploadedUserId)
+            .url("")
+            .build())
+        .toList();
+
+    var savedGalleries = galleryRepository.saveAllAndFlush(galleries);
+
+    for (int i = 0; i < savedGalleries.size(); i++) {
+      var gallery = savedGalleries.get(i);
+      var photo = validPhotos.get(i);
+      var key = buildS3Key(heroId, gallery.getId(), photo.fileName());
+
+      s3UploadService.upload(key, photo.bytes());
+      gallery.setUrl(key);
+      photoUploadEventPublisher.publishPhotoUploadEvent(gallery.getId(), heroId, key);
+    }
+
+    return galleryRepository.saveAllAndFlush(savedGalleries);
+  }
+
+  private String buildS3Key(Long heroId, Long galleryId, String fileName) {
+    return NEW_STORY_IMAGE_BASE_PATH_FORMAT.formatted(heroId, galleryId) + fileName;
+  }
+
+  public record FacebookImportPhoto(String fileName, byte[] bytes) {}
 
 
   @Transactional

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/GalleryWriteService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/GalleryWriteService.java
@@ -2,14 +2,13 @@ package io.itmca.lifepuzzle.domain.content.service;
 
 import static io.itmca.lifepuzzle.domain.content.type.GalleryType.IMAGE;
 import static io.itmca.lifepuzzle.domain.content.type.GalleryType.VIDEO;
+import static io.itmca.lifepuzzle.global.constants.FileConstant.NEW_STORY_IMAGE_BASE_PATH_FORMAT;
 
 import io.itmca.lifepuzzle.domain.content.endpoint.response.GalleryUploadCompleteResponse;
 import io.itmca.lifepuzzle.domain.content.endpoint.response.dto.GalleryUploadResultDto;
 import io.itmca.lifepuzzle.domain.content.entity.Gallery;
 import io.itmca.lifepuzzle.domain.content.event.PhotoUploadEventPublisher;
 import io.itmca.lifepuzzle.domain.content.repository.GalleryRepository;
-import static io.itmca.lifepuzzle.global.constants.FileConstant.NEW_STORY_IMAGE_BASE_PATH_FORMAT;
-
 import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
 import io.itmca.lifepuzzle.domain.content.type.GallerySource;
 import io.itmca.lifepuzzle.domain.content.type.GalleryStatus;

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/PresignedUrlService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/service/PresignedUrlService.java
@@ -8,6 +8,7 @@ import io.itmca.lifepuzzle.domain.content.endpoint.response.PresignedUrlResponse
 import io.itmca.lifepuzzle.domain.content.entity.Gallery;
 import io.itmca.lifepuzzle.domain.content.repository.GalleryRepository;
 import io.itmca.lifepuzzle.domain.content.type.AgeGroup;
+import io.itmca.lifepuzzle.domain.content.type.GallerySource;
 import io.itmca.lifepuzzle.domain.content.type.GalleryStatus;
 import io.itmca.lifepuzzle.domain.content.type.GalleryType;
 import java.time.Duration;
@@ -43,6 +44,7 @@ public class PresignedUrlService {
               .url("")
               .ageGroup(ageGroup)
               .galleryType(determineGalleryType(file.contentType()))
+              .source(GallerySource.UPLOAD)
               .galleryStatus(GalleryStatus.PENDING)
               .build()
       );

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/type/GallerySource.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/content/type/GallerySource.java
@@ -1,0 +1,6 @@
+package io.itmca.lifepuzzle.domain.content.type;
+
+public enum GallerySource {
+  UPLOAD,
+  FACEBOOK
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/hero/entity/Hero.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/hero/entity/Hero.java
@@ -60,6 +60,8 @@ public class Hero {
   @Setter
   private Boolean isLunar;
 
+  private String facebookUserId;
+
   public static Hero defaultHero() {
     return Hero.builder()
         .name("주인공")
@@ -84,5 +86,9 @@ public class Hero {
 
   public boolean isActive() {
     return this.deletedAt == null;
+  }
+
+  public void setFacebookUserId(String facebookUserId) {
+    this.facebookUserId = facebookUserId;
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/hero/repository/HeroRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/hero/repository/HeroRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface HeroRepository extends JpaRepository<Hero, Long> {
   @EntityGraph(attributePaths = {"heroUserAuths"})
   Optional<Hero> findByHeroNoAndDeletedAtIsNull(Long heroNo);
+
+  Optional<Hero> findByFacebookUserId(String facebookUserId);
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/entity/User.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/entity/User.java
@@ -44,7 +44,6 @@ public class User {
   private String nickName;
   private String kakaoId;
   private String appleId;
-  private String facebookUserId;
   private boolean pushOptIn;
   private String image;
 
@@ -96,9 +95,5 @@ public class User {
     } else {
       this.image = userProfileImage.getFileName();
     }
-  }
-
-  public void setFacebookUserId(String facebookUserId) {
-    this.facebookUserId = facebookUserId;
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/entity/User.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/entity/User.java
@@ -44,6 +44,7 @@ public class User {
   private String nickName;
   private String kakaoId;
   private String appleId;
+  private String facebookUserId;
   private boolean pushOptIn;
   private String image;
 
@@ -95,5 +96,9 @@ public class User {
     } else {
       this.image = userProfileImage.getFileName();
     }
+  }
+
+  public void setFacebookUserId(String facebookUserId) {
+    this.facebookUserId = facebookUserId;
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/repository/UserRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByKakaoId(String kakaoId);
 
   Optional<User> findByAppleId(String appleId);
+
+  Optional<User> findByFacebookUserId(String facebookUserId);
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/repository/UserRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/repository/UserRepository.java
@@ -17,6 +17,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByKakaoId(String kakaoId);
 
   Optional<User> findByAppleId(String appleId);
-
-  Optional<User> findByFacebookUserId(String facebookUserId);
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/config/SecurityConfig.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/config/SecurityConfig.java
@@ -27,7 +27,10 @@ public class SecurityConfig {
                     "/v3/**", "/question/*", "/questions/*",
                     "/share/hero", "/swagger-ui/**", "/stories/**",
                     "/.well-know/assetlinks.json", "/.well-known/assetlinks.json",
-                    ".well-known/apple-app-site-association", "/v1/facebook/**")
+                    ".well-known/apple-app-site-association",
+                    "/v1/facebook/callback",
+                    "/v1/facebook/data-deletion",
+                    "/v1/facebook/data-deletion/status")
                 .permitAll()
                 .anyRequest()
                 .authenticated()

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/FacebookUserAlreadyLinkedException.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/FacebookUserAlreadyLinkedException.java
@@ -1,0 +1,9 @@
+package io.itmca.lifepuzzle.global.exception;
+
+import io.itmca.lifepuzzle.global.exception.handler.AlreadyExistsException;
+
+public class FacebookUserAlreadyLinkedException extends AlreadyExistsException {
+  public FacebookUserAlreadyLinkedException(String facebookUserId) {
+    super(String.format("Facebook user already linked - facebookUserId: %s", facebookUserId));
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/InvalidSignedRequestException.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/exception/InvalidSignedRequestException.java
@@ -1,0 +1,9 @@
+package io.itmca.lifepuzzle.global.exception;
+
+import io.itmca.lifepuzzle.global.exception.handler.MissingArgumentException;
+
+public class InvalidSignedRequestException extends MissingArgumentException {
+  public InvalidSignedRequestException() {
+    super("signed_request is invalid.");
+  }
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/file/repository/S3Repository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/file/repository/S3Repository.java
@@ -5,6 +5,7 @@ import io.awspring.cloud.s3.S3Resource;
 import io.itmca.lifepuzzle.global.constants.FileConstant;
 import io.itmca.lifepuzzle.global.file.CustomFile;
 import io.itmca.lifepuzzle.global.util.FileUtil;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -59,6 +60,17 @@ public class S3Repository implements FileRepository {
         boolean deleted = localFile.delete();
         log.debug("Local temp file cleanup - path: {}, deleted: {}", localFile.getAbsolutePath(), deleted);
       }
+    }
+  }
+
+  public void upload(String key, byte[] bytes) throws IOException {
+    log.debug("S3Repository upload - bucket: {}, s3Key: {}, bytes: {}", bucket, key, bytes.length);
+    try (InputStream inputFile = new ByteArrayInputStream(bytes)) {
+      s3Operations.upload(bucket, key, inputFile);
+      log.debug("S3 upload completed successfully - key: {}", key);
+    } catch (IOException e) {
+      log.error("S3 upload failed - bucket: {}, key: {}, error: {}", bucket, key, e.getMessage(), e);
+      throw e;
     }
   }
 

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/file/service/S3UploadService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/global/file/service/S3UploadService.java
@@ -40,6 +40,26 @@ public class S3UploadService {
     }
   }
 
+  public void upload(String key, byte[] bytes) {
+    final long startTime = System.currentTimeMillis();
+
+    log.info("Starting S3 upload - key: {}, fileSize: {} bytes", key, bytes.length);
+
+    try {
+      s3Repository.upload(key, bytes);
+      final long duration = System.currentTimeMillis() - startTime;
+
+      log.info("S3 upload successful - key: {}, duration: {}ms", key, duration);
+    } catch (IOException e) {
+      final long duration = System.currentTimeMillis() - startTime;
+
+      log.error("S3 upload failed - key: {}, fileSize: {} bytes, duration: {}ms, error: {}",
+          key, bytes.length, duration, e.getMessage(), e);
+
+      throw new S3UploadFailException(key, e);
+    }
+  }
+
   public void upload(List<? extends CustomFile> customFiles) {
     log.info("Starting batch S3 upload - total files: {}", customFiles.size());
     

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_facebook_user_id_and_gallery_source.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_facebook_user_id_and_gallery_source.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `user`
+  ADD COLUMN `facebook_user_id` varchar(128) DEFAULT NULL COMMENT '페이스북 사용자 ID',
+  ADD UNIQUE KEY `uk_user_facebook_user_id` (`facebook_user_id`);
+
+ALTER TABLE `gallery`
+  ADD COLUMN `source` varchar(32) NOT NULL DEFAULT 'UPLOAD' COMMENT '사진 출처',
+  ADD COLUMN `uploaded_user_id` bigint DEFAULT NULL COMMENT '업로드한 사용자 ID',
+  ADD KEY `idx_gallery_uploaded_user_id` (`uploaded_user_id`);

--- a/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_facebook_user_id_and_gallery_source.sql
+++ b/services/lifepuzzle-api/src/main/resources/db/migration/V3__add_facebook_user_id_and_gallery_source.sql
@@ -1,6 +1,6 @@
-ALTER TABLE `user`
+ALTER TABLE `hero`
   ADD COLUMN `facebook_user_id` varchar(128) DEFAULT NULL COMMENT '페이스북 사용자 ID',
-  ADD UNIQUE KEY `uk_user_facebook_user_id` (`facebook_user_id`);
+  ADD UNIQUE KEY `uk_hero_facebook_user_id` (`facebook_user_id`);
 
 ALTER TABLE `gallery`
   ADD COLUMN `source` varchar(32) NOT NULL DEFAULT 'UPLOAD' COMMENT '사진 출처',


### PR DESCRIPTION
## 작업 배경
- Facebook 사진을 S3에 보관하고 삭제 콜백에서 제거할 수 있도록 정책 대응이 필요했습니다.

## 작업 내용
### Facebook 사진 Import 및 저장
- Facebook 사진 import 시 S3 업로드 및 gallery source/업로더 식별자 저장
- Hero별로 Facebook 계정 연동 (facebook_user_id를 hero 테이블에 저장)
- 한 명의 user가 여러 hero를 관리할 수 있으며, 각 hero마다 Facebook에서 독립적으로 사진 가져오기 가능

### Facebook 데이터 삭제 콜백
- 데이터 삭제 콜백에서 hero의 facebook_user_id 기준으로 S3/갤러리 데이터 삭제
- Facebook 계정과 연동된 hero의 모든 Facebook 소스 갤러리 데이터 삭제

### 스키마 변경
- hero 테이블에 facebook_user_id 컬럼 추가 (unique key)
- gallery 테이블에 source, uploaded_user_id 컬럼 추가
- 갤러리 응답에 source 포함

### 기타
- 공개 엔드포인트 범위 정리
- Import 순서 정렬 (Checkstyle 규칙 준수)

## 설계 결정
- facebook_user_id를 user가 아닌 hero 레벨에 저장하는 이유:
  - 한 명의 user가 여러 hero(주인공)를 관리
  - 각 hero마다 다른 Facebook 계정에서 사진을 가져올 수 있음
  - Hero별로 독립적인 Facebook 연동 및 데이터 관리 필요

## 참고 사항
- 테스트는 실행하지 않았습니다.