### PR TITLE
Wrap duplicate check response in DTO

### DIFF
--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/endpoint/UserValidateEndpoint.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/endpoint/UserValidateEndpoint.java
@@ -1,7 +1,7 @@
 package io.itmca.lifepuzzle.domain.user.endpoint;
 
+import io.itmca.lifepuzzle.domain.user.endpoint.response.IdDuplicateCheckResponse;
 import io.itmca.lifepuzzle.domain.user.service.UserQueryService;
-import io.itmca.lifepuzzle.global.exception.handler.NotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,15 +18,10 @@ public class UserValidateEndpoint {
 
   private final UserQueryService userQueryService;
 
-  @GetMapping({"/v1/users/dupcheck/id"})
+  @GetMapping("/v1/users/dupcheck/id")
   @Operation(summary = "아이디 중복 체크")
-  public boolean checkId(@RequestParam("id") String id) {
-    try {
-      userQueryService.findByLoginId(id);
-    } catch (NotFoundException e) {
-      return false;
-    }
-
-    return true;
+  public IdDuplicateCheckResponse checkId(@RequestParam("id") String id) {
+    boolean duplicated = userQueryService.existsByLoginId(id);
+    return new IdDuplicateCheckResponse(duplicated);
   }
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/endpoint/response/IdDuplicateCheckResponse.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/endpoint/response/IdDuplicateCheckResponse.java
@@ -1,0 +1,5 @@
+package io.itmca.lifepuzzle.domain.user.endpoint.response;
+
+public record IdDuplicateCheckResponse(boolean duplicated) {
+
+}

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/repository/UserRepository.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByKakaoId(String kakaoId);
 
   Optional<User> findByAppleId(String appleId);
+
+  boolean existsByLoginId(String loginId);
 }

--- a/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/service/UserQueryService.java
+++ b/services/lifepuzzle-api/src/main/java/io/itmca/lifepuzzle/domain/user/service/UserQueryService.java
@@ -38,4 +38,8 @@ public class UserQueryService {
     return userRepository.findByAppleId(appleId)
         .orElseThrow(() -> new AppleUserNotFoundException(appleId));
   }
+
+  public boolean existsByLoginId(String loginId) {
+    return userRepository.existsByLoginId(loginId);
+  }
 }


### PR DESCRIPTION
## 작업 배경
- 아이디 중복 체크 API(`/v1/users/dupcheck/id`)가 raw boolean을 반환하고 있어 의미가 불명확함
- 예외 기반 로직으로 존재 여부를 판단하는 비효율적인 구조

## 작업 내용
- **IdDuplicateCheckResponse** DTO 신규 생성
  - `duplicated` 필드로 중복 여부를 명확하게 표현
  - API 응답: `true`/`false` → `{"duplicated": true/false}`

- **UserRepository** 개선
  - `existsByLoginId(String loginId)` 메서드 추가
  - JPA derived query로 효율적인 존재 여부 확인

- **UserQueryService** 개선
  - `existsByLoginId()` 메서드 추가

- **UserValidateEndpoint** 리팩토링
  - 예외 기반 로직 → `existsByLoginId()` 직접 호출
  - 반환 타입: `boolean` → `IdDuplicateCheckResponse`

## 참고 사항
- API 응답 형식 변경으로 클라이언트 수정이 필요합니다
- 기존 테스트 실패(`HeroAuthEndpointTest`, `UserHeroEndpointTest`)는 main 브랜치에도 동일하게 존재하는 기존 이슈입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)