### PR TITLE
Upgrade Spring Boot to 3.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.3.2' apply false
+    id 'org.springframework.boot' version '3.4.1' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
 }
 

--- a/services/lifepuzzle-api/build.gradle
+++ b/services/lifepuzzle-api/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version '3.3.2'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
     id 'java'
     id 'checkstyle'
 }


### PR DESCRIPTION
## 작업 배경
- lifepuzzle-api 실행 시 `Failed to introspect Class [org.springdoc.webmvc.ui.SwaggerConfig]` 에러 발생
- `NoClassDefFoundError: org/springframework/web/servlet/resource/LiteWebJarsResourceResolver` 에러의 원인은 Spring Boot 3.3.x와 springdoc-openapi 2.7.0+ 간의 호환성 문제
- springdoc-openapi 2.7.0 이상은 Spring Boot 3.4.0 이상이 필요함

## 작업 내용
- **Spring Boot 버전 업그레이드**: 3.3.2 → 3.4.1
  - 루트 `build.gradle`에서 버전 업데이트
  - `services/lifepuzzle-api/build.gradle`에서 중복 버전 지정 제거 (루트에서 상속)

## 참고 사항
- [springdoc-openapi 호환성 이슈](https://github.com/springdoc/springdoc-openapi/issues/2789)
- Spring Boot 3.4.x는 graceful shutdown이 기본 활성화됨 - 필요시 `server.shutdown=immediate` 설정으로 이전 동작 복원 가능
- 모든 테스트 통과 확인 (HeroAuthEndpointTest, UserHeroEndpointTest 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)