### PR TITLE
Migrate to Gradle Version Catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version '3.4.1' apply false
-    id 'io.spring.dependency-management' version '1.1.7' apply false
+    alias(libs.plugins.spring.boot) apply false
+    alias(libs.plugins.spring.dependency.management) apply false
 }
 
 static def getDate() {
@@ -10,7 +10,7 @@ static def getDate() {
 allprojects {
     group = 'io.itmca'
     version = getDate()
-    
+
     repositories {
         mavenCentral()
         maven {
@@ -22,21 +22,16 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    
+
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(libs.versions.java.get())
         }
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
-    
+
     tasks.named('test') {
         useJUnitPlatform()
     }
-}
-
-ext {
-    sentryVersion = '8.12.0'
-    jwtVersion = '0.12.6'
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,91 @@
+[versions]
+# Java
+java = "21"
+
+# Spring
+spring-boot = "3.4.1"
+spring-dependency-management = "1.1.7"
+spring-cloud-aws = "3.4.0"
+spring-cloud-stream = "4.1.3"
+
+# Security
+jwt = "0.12.6"
+nimbus-jose-jwt = "10.5"
+sentry = "8.20.0"
+
+# Database
+flyway = "11.15.0"
+
+# Testing
+testcontainers = "1.21.3"
+database-rider = "1.44.0"
+fixture-monkey = "1.1.11"
+mysql-connector-legacy = "8.0.33"
+javax-persistence = "2.2"
+
+# Tools
+lombok = "1.18.38"
+json = "20240303"
+iv-compressor = "2.0.2"
+tika = "3.2.0"
+springdoc = "2.8.13"
+checkstyle = "10.10.0"
+
+[libraries]
+# Spring Boot Starters
+spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
+spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
+spring-boot-starter-thymeleaf = { module = "org.springframework.boot:spring-boot-starter-thymeleaf" }
+spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
+spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
+spring-boot-starter-mail = { module = "org.springframework.boot:spring-boot-starter-mail" }
+spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
+
+# Spring Security
+spring-security-test = { module = "org.springframework.security:spring-security-test" }
+
+# Spring Cloud
+spring-cloud-aws-starter-s3 = { module = "io.awspring.cloud:spring-cloud-aws-starter-s3", version.ref = "spring-cloud-aws" }
+spring-cloud-stream-rabbit = { module = "org.springframework.cloud:spring-cloud-starter-stream-rabbit", version.ref = "spring-cloud-stream" }
+
+# Security / JWT
+jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jwt" }
+jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jwt" }
+jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jwt" }
+nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt" }
+
+# Sentry
+sentry-spring-boot = { module = "io.sentry:sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
+sentry-logback = { module = "io.sentry:sentry-logback", version.ref = "sentry" }
+
+# Database
+mysql-connector = { module = "com.mysql:mysql-connector-j" }
+flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+flyway-mysql = { module = "org.flywaydb:flyway-mysql", version.ref = "flyway" }
+
+# Testing
+testcontainers-junit = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
+testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "testcontainers" }
+database-rider-junit5 = { module = "com.github.database-rider:rider-junit5", version.ref = "database-rider" }
+database-rider-spring = { module = "com.github.database-rider:rider-spring", version.ref = "database-rider" }
+fixture-monkey = { module = "com.navercorp.fixturemonkey:fixture-monkey-starter", version.ref = "fixture-monkey" }
+mysql-connector-legacy = { module = "mysql:mysql-connector-java", version.ref = "mysql-connector-legacy" }
+javax-persistence = { module = "javax.persistence:javax.persistence-api", version.ref = "javax-persistence" }
+
+# Tools
+lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
+json = { module = "org.json:json", version.ref = "json" }
+iv-compressor = { module = "io.github.techgnious:IVCompressor", version.ref = "iv-compressor" }
+tika-core = { module = "org.apache.tika:tika-core", version.ref = "tika" }
+tika-parsers = { module = "org.apache.tika:tika-parsers-standard-package", version.ref = "tika" }
+
+# Documentation
+springdoc-openapi = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
+
+[plugins]
+spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }

--- a/services/ai-video-generator/build.gradle
+++ b/services/ai-video-generator/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
     id 'java'
     id 'checkstyle'
 }
@@ -18,7 +18,7 @@ version = getDate()
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(libs.versions.java.get())
     }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
@@ -32,45 +32,39 @@ repositories {
     }
 }
 
-ext {
-    sentryVersion = '8.12.0'
-    jwtVersion = '0.12.6'
-}
-
 dependencies {
     // Shared modules
     implementation project(':shared:java-common')
-    
+
     // Web
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation libs.spring.boot.starter.web
+    implementation libs.spring.boot.starter.webflux
 
     // AWS
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
-    
+    implementation libs.spring.cloud.aws.starter.s3
+
     // Spring Cloud Stream RabbitMQ
-    implementation 'org.springframework.cloud:spring-cloud-starter-stream-rabbit:4.1.3'
+    implementation libs.spring.cloud.stream.rabbit
 
     // Data
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation libs.spring.boot.starter.data.jpa
+    runtimeOnly libs.mysql.connector
 
     // Monitoring
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation libs.spring.boot.starter.actuator
 
     // Security (for basic auth if needed)
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation libs.spring.boot.starter.security
 
     // Tool
-    compileOnly 'org.projectlombok:lombok:1.18.38'
-    annotationProcessor 'org.projectlombok:lombok:1.18.38'
-    implementation 'org.json:json:20240303'
-    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    compileOnly libs.lombok
+    annotationProcessor libs.lombok
+    implementation libs.json
+    implementation libs.spring.boot.starter.aop
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation libs.springdoc.openapi
 }
-
 
 processResources {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
@@ -89,7 +83,7 @@ task buildZip(type: Zip) {
 }
 
 checkstyle {
-    toolVersion('10.10.0')
+    toolVersion(libs.versions.checkstyle.get())
     configFile = rootProject.file('tools/checkstyle/checkstyle.xml')
     maxWarnings = 0
 }

--- a/services/lifepuzzle-api/build.gradle
+++ b/services/lifepuzzle-api/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
     id 'java'
     id 'checkstyle'
 }
@@ -18,7 +18,7 @@ version = getDate()
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(libs.versions.java.get())
     }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
@@ -32,71 +32,66 @@ repositories {
     }
 }
 
-ext {
-    sentryVersion = '8.20.0'
-    jwtVersion = '0.12.6'
-}
-
 dependencies {
     // Shared modules
     implementation project(':shared:java-common')
-    
+
     // Web
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation libs.spring.boot.starter.web
+    implementation libs.spring.boot.starter.thymeleaf
+    implementation libs.spring.boot.starter.webflux
 
     // AWS
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
-    
+    implementation libs.spring.cloud.aws.starter.s3
+
     // Spring Cloud Stream RabbitMQ
-    implementation 'org.springframework.cloud:spring-cloud-starter-stream-rabbit:4.1.3'
+    implementation libs.spring.cloud.stream.rabbit
 
     // Security
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation "io.jsonwebtoken:jjwt-api:${jwtVersion}"
-    runtimeOnly "io.jsonwebtoken:jjwt-impl:${jwtVersion}"
-    runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jwtVersion}"
-    implementation 'com.nimbusds:nimbus-jose-jwt:10.5'
-    implementation "io.sentry:sentry-spring-boot-starter-jakarta:${sentryVersion}"
-    implementation "io.sentry:sentry-logback:${sentryVersion}"
+    implementation libs.spring.boot.starter.security
+    implementation libs.jjwt.api
+    runtimeOnly libs.jjwt.impl
+    runtimeOnly libs.jjwt.jackson
+    implementation libs.nimbus.jose.jwt
+    implementation libs.sentry.spring.boot
+    implementation libs.sentry.logback
 
     // Data
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation libs.spring.boot.starter.data.jpa
+    runtimeOnly libs.mysql.connector
 
     // Monitoring
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation libs.spring.boot.starter.actuator
 
-    //	Test
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.11")
+    // Test
+    testImplementation libs.spring.boot.starter.test
+    testImplementation libs.spring.security.test
+    testImplementation libs.fixture.monkey
 
-    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation libs.spring.boot.testcontainers
 
-    testImplementation("org.testcontainers:junit-jupiter:1.21.3")
-    testImplementation("org.testcontainers:mysql:1.21.3")
-    testImplementation("com.github.database-rider:rider-junit5:1.44.0")
-    testImplementation("com.github.database-rider:rider-spring:1.44.0")
-    testImplementation 'mysql:mysql-connector-java:8.0.33'
-    testImplementation 'javax.persistence:javax.persistence-api:2.2' // DBRider 실행 시 오류 해결을 위해 추가되었다.
+    testImplementation libs.testcontainers.junit
+    testImplementation libs.testcontainers.mysql
+    testImplementation libs.database.rider.junit5
+    testImplementation libs.database.rider.spring
+    testImplementation libs.mysql.connector.legacy
+    testImplementation libs.javax.persistence // DBRider 실행 시 오류 해결을 위해 추가되었다.
 
     // Tool
-    compileOnly 'org.projectlombok:lombok:1.18.38'
-    annotationProcessor 'org.projectlombok:lombok:1.18.38'
-    implementation 'org.json:json:20240303'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'io.github.techgnious:IVCompressor:2.0.2'
-    implementation 'org.springframework.boot:spring-boot-starter-aop'
-    implementation 'org.apache.tika:tika-core:3.2.0'
-    implementation 'org.apache.tika:tika-parsers-standard-package:3.2.0'
+    compileOnly libs.lombok
+    annotationProcessor libs.lombok
+    implementation libs.json
+    implementation libs.spring.boot.starter.mail
+    implementation libs.iv.compressor
+    implementation libs.spring.boot.starter.aop
+    implementation libs.tika.core
+    implementation libs.tika.parsers
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+    implementation libs.springdoc.openapi
 
-    implementation 'org.flywaydb:flyway-core:11.15.0'
-    implementation 'org.flywaydb:flyway-mysql:11.15.0'
+    implementation libs.flyway.core
+    implementation libs.flyway.mysql
 }
 
 tasks.named('test') {
@@ -120,7 +115,7 @@ task buildZip(type: Zip) {
 }
 
 checkstyle {
-    toolVersion('10.10.0')
+    toolVersion(libs.versions.checkstyle.get())
     configFile = rootProject.file('tools/checkstyle/checkstyle.xml')
     maxWarnings = 0
 }

--- a/shared/java-common/build.gradle
+++ b/shared/java-common/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'io.spring.dependency-management'
+    alias(libs.plugins.spring.dependency.management)
 }
 
 static def getDate() {
@@ -12,7 +12,7 @@ version = getDate()
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(libs.versions.java.get())
     }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
@@ -30,12 +30,12 @@ dependencyManagement {
 
 dependencies {
     // Common utilities and shared code
-    api 'org.springframework.boot:spring-boot-starter'
-    api 'org.projectlombok:lombok:1.18.38'
-    annotationProcessor 'org.projectlombok:lombok:1.18.38'
-    
+    api libs.spring.boot.starter
+    api libs.lombok
+    annotationProcessor libs.lombok
+
     // Testing
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation libs.spring.boot.starter.test
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 작업 배경
- 기존에는 각 모듈의 build.gradle 파일에 의존성 버전이 분산되어 있어 버전 관리가 어려웠음
- 동일한 의존성이 여러 모듈에서 사용될 때 버전 불일치 위험이 있었음
- 의존성 업그레이드 시 여러 파일을 수정해야 하는 번거로움이 있었음

## 작업 내용
- `gradle/libs.versions.toml` 파일을 추가하여 모든 의존성 버전을 중앙 집중 관리
- 모든 build.gradle 파일에서 하드코딩된 버전을 Version Catalog 참조로 변경

### 변경된 파일
1. **gradle/libs.versions.toml** (신규)
   - `[versions]` 섹션: Spring Boot, JWT, Sentry, Flyway 등 모든 버전 정보
   - `[libraries]` 섹션: 의존성 정의 (모듈 + 버전 참조)
   - `[plugins]` 섹션: Gradle 플러그인 정의

2. **build.gradle** (루트)
   - 플러그인을 `alias(libs.plugins.*)` 형식으로 변경
   - `ext {}` 블록의 공통 버전 변수 제거

3. **services/lifepuzzle-api/build.gradle**
   - 모든 의존성을 `libs.*` 형식으로 변경
   - `ext {}` 블록 제거

4. **services/ai-video-generator/build.gradle**
   - 모든 의존성을 `libs.*` 형식으로 변경
   - `ext {}` 블록 제거

5. **shared/java-common/build.gradle**
   - 모든 의존성을 `libs.*` 형식으로 변경

## 참고 사항
- Gradle 7.0+ 에서 공식 지원하는 Version Catalog 기능 활용
- 이후 의존성 버전 업그레이드는 `gradle/libs.versions.toml` 파일만 수정하면 됨
- 빌드 및 테스트 정상 동작 확인 완료